### PR TITLE
Use base64.URLEncoding instead of base64.StdEncoding for state parameter

### DIFF
--- a/oauth2/login.go
+++ b/oauth2/login.go
@@ -104,7 +104,7 @@ func CallbackHandler(config *oauth2.Config, success, failure ctxh.ContextHandler
 func randomState() string {
 	b := make([]byte, 32)
 	rand.Read(b)
-	return base64.StdEncoding.EncodeToString(b)
+	return base64.URLEncoding.EncodeToString(b)
 }
 
 // parseCallback parses the "code" and "state" parameters from the http.Request


### PR DESCRIPTION
standard base64 encoding may contain a space characters and there are some situations when session has state with '+' characters but request comes in with ' ' instead of '+'
