### PR TITLE
Use base64.RawURLEncoding for StateHandler's state param

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ go:
   - 1.6
   - 1.7
   - tip
+matrix:
+  allow_failures:
+    - go: tip
 install:
   - go get github.com/golang/lint/golint
   - go get -v -t ./...

--- a/oauth2/login.go
+++ b/oauth2/login.go
@@ -104,7 +104,7 @@ func CallbackHandler(config *oauth2.Config, success, failure ctxh.ContextHandler
 func randomState() string {
 	b := make([]byte, 32)
 	rand.Read(b)
-	return base64.URLEncoding.EncodeToString(b)
+	return base64.RawURLEncoding.EncodeToString(b)
 }
 
 // parseCallback parses the "code" and "state" parameters from the http.Request

--- a/oauth2/login.go
+++ b/oauth2/login.go
@@ -104,7 +104,7 @@ func CallbackHandler(config *oauth2.Config, success, failure ctxh.ContextHandler
 func randomState() string {
 	b := make([]byte, 32)
 	rand.Read(b)
-	return base64.StdEncoding.EncodeToString(b)
+	return base64.URLEncoding.EncodeToString(b)
 }
 
 // parseCallback parses the "code" and "state" parameters from the http.Request


### PR DESCRIPTION
* Avoid using '+' in the state param. A random state value may contain it and some OAuth 2 providers do
not correctly URL encode their callback URLs. As a result, the parsed and checked state doesn't match.
* See #12