### PR TITLE
Use Standard library context in Go 1.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,27 +50,15 @@ Create small, chainable handlers to correctly implement the steps of common auth
 
 ## Concept
 
-Package `gologin` provides `ContextHandler`'s which can be chained together to implement authorization flows and pass data (e.g. tokens, users) in a `ctx` argument.
-
-```go
-type ContextHandler interface {
-    ServeHTTP(ctx context.Context, w http.ResponseWriter, req *http.Request)
-}
-```
+Package `gologin` provides `http.Handler`'s which can be chained together to implement authorization flows and pass data (e.g. tokens, users) in request context.
 
 For example, `oauth2` has handlers which generate a state parameter, redirect users to an AuthURL, or validate a redirectURL callback to exchange for a Token.
 
-`gologin` handlers generally take `success` and `failure` ContextHandlers to be called next if an authentication step succeeds or fails. They populate the `ctx` with values needed for the next step. If the flow succeeds, the last success ContextHandler `ctx` should include the access token and (optional) associated User/Account.
-
-[ctxh](https://github.com/dghubble/ctxh) defines a ContextHandler and some convenience functions to convert to a handler which plays well with `net/http`.
-
-```go
-func NewHandler(h ContextHandler) http.Handler
-```
+`gologin` handlers generally take `success` and `failure` http.Handlers to be called next if an authentication step succeeds or fails. They populate the request context with values needed for the next step. If the flow succeeds, the last success Handler should include the access token and (optional) associated User/Account.
 
 ## Usage
 
-Choose an auth provider package such as `github` or `twitter`. These packages chain together lower level `oauth1` and `oauth2` ContextHandlers and fetch the Github or Twitter `User` before calling your success ContextHandler.
+Choose an auth provider package such as `github` or `twitter`. These packages chain together lower level `oauth1` and `oauth2` Handlers and fetch the Github or Twitter `User` before calling your success Handler.
 
 Let's walk through Github and Twitter web login examples.
 
@@ -87,28 +75,29 @@ config := &oauth2.Config{
 }
 mux := http.NewServeMux()
 stateConfig := gologin.DebugOnlyCookieConfig
-mux.Handle("/login", ctxh.NewHandler(github.StateHandler(stateConfig, github.LoginHandler(config, nil))))
-mux.Handle("/callback", ctxh.NewHandler(github.StateHandler(stateConfig, github.CallbackHandler(config, issueSession(), nil))))
+mux.Handle("/login", github.StateHandler(stateConfig, github.LoginHandler(config, nil)))
+mux.Handle("/callback", github.StateHandler(stateConfig, github.CallbackHandler(config, issueSession(), nil)))
 ```
 
-The `StateHandler` checks for an OAuth2 state parameter cookie, generates a non-guessable state as a short-lived cookie if missing, and passes the state value in the ctx. The `CookieConfig` allows the cookie name or expiration (default 60 seconds) to be configured. In production, use a config like `gologin.DefaultCookieConfig` which sets *Secure* true to require cookies be sent over HTTPS. If you wish to persist state parameters a different way, you may chain your own `ContextHandler`. ([info](#state-parameters))
+The `StateHandler` checks for an OAuth2 state parameter cookie, generates a non-guessable state as a short-lived cookie if missing, and passes the state value in the ctx. The `CookieConfig` allows the cookie name or expiration (default 60 seconds) to be configured. In production, use a config like `gologin.DefaultCookieConfig` which sets *Secure* true to require cookies be sent over HTTPS. If you wish to persist state parameters a different way, you may chain your own `http.Handler`. ([info](#state-parameters))
 
-The `github` `LoginHandler` reads the state from the ctx and redirects to the AuthURL (at github.com) to prompt the user to grant access. Passing nil for the `failure` ContextHandler just means the `DefaultFailureHandler` should be used, which reports errors. ([info](#failure-handlers))
+The `github` `LoginHandler` reads the state from the ctx and redirects to the AuthURL (at github.com) to prompt the user to grant access. Passing nil for the `failure` Handler just means the `DefaultFailureHandler` should be used, which reports errors. ([info](#failure-handlers))
 
 The `github` `CallbackHandler` receives an auth code and state OAuth2 redirection, validates the state against the state in the ctx, and exchanges the auth code for an OAuth2 Token. The `github` CallbackHandler wraps the lower level `oauth2` `CallbackHandler` to further use the Token to obtain the Github `User` before calling through to the success or failure handlers.
 
 <img src="https://storage.googleapis.com/dghubble/gologin-github.png">
 
-Next, write the success `ContextHandler` to do something with the Token and Github User added to the `ctx`.
+Next, write the success `http.Handler` to do something with the Token and Github User added to the `ctx`.
 
 ```go
-func issueSession() ctxh.ContextHandler {
-    fn := func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+func issueSession() http.Handler {
+    fn := func(w http.ResponseWriter, req *http.Request) {
+        ctx := req.Context()
         token, _ := oauth2Login.TokenFromContext(ctx)
         githubUser, err := github.UserFromContext(ctx)
         // handle errors and grant the visitor a session (cookie, token, etc.)
     }
-    return ctxh.ContextHandlerFunc(fn)
+    return http.HandlerFunc(fn)
 }
 ```
 
@@ -130,22 +119,23 @@ mux.Handle("/login", ctxh.NewHandler(twitter.LoginHandler(config, nil)))
 mux.Handle("/callback", ctxh.NewHandler(twitter.CallbackHandler(config, issueSession(), nil)))
 ```
 
-The `twitter` `LoginHandler` obtains a request token and secret, adds them to the ctx, and redirects to the AuthorizeURL to prompt the user to grant access. Passing nil for the `failure` ContextHandler just means the `DefaultFailureHandler` should be used, which reports errors. ([info](#failure-handlers))
+The `twitter` `LoginHandler` obtains a request token and secret, adds them to the ctx, and redirects to the AuthorizeURL to prompt the user to grant access. Passing nil for the `failure` http.Handler just means the `DefaultFailureHandler` should be used, which reports errors. ([info](#failure-handlers))
 
 The `twitter` `CallbackHandler` receives an OAuth1 token and verifier, reads the request secret from the ctx, and obtains an OAuth1 access token and secret. The `twitter` CallbackHandler wraps the lower level `oauth1` CallbackHandler to further use the access token/secret to obtain the Twitter `User` before calling through to the success or failure handlers.
 
 <img src="https://storage.googleapis.com/dghubble/gologin-twitter.png">
 
-Next, write the success `ContextHandler` to do something with the access token/secret and Twitter User added to the `ctx`.
+Next, write the success `Handler` to do something with the access token/secret and Twitter User added to the `ctx`.
 
 ```go
-func success() ctxh.ContextHandler {
-    fn := func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+func success() http.Handler {
+    fn := func(w http.ResponseWriter, req *http.Request) {
+        ctx := req.Context()
         accessToken, accessSecret, _ := oauth1Login.AccessTokenFromContext(ctx)
         twitterUser, err := twitter.UserFromContext(ctx)
         // handle errors and grant the visitor a session (cookie, token, etc.)
     }
-    return ctxh.ContextHandlerFunc(fn)
+    return http.HandlerFunc(fn)
 }
 ```
 
@@ -155,13 +145,13 @@ See the [Twitter tutorial](examples/twitter) for a web app you can run from the 
 
 ### State Parameters
 
-OAuth2 `StateHandler` implements OAuth 2 [RFC 6749](https://tools.ietf.org/html/rfc6749) 10.12 CSRF Protection using non-guessable values in short-lived HTTPS-only cookies to provide reasonable assurance the user in the login phase and callback phase are the same. If you wish to implement this differently, write a `ContextHandler` which sets a *state* in the ctx, which is expected by LoginHandler and CallbackHandler.
+OAuth2 `StateHandler` implements OAuth 2 [RFC 6749](https://tools.ietf.org/html/rfc6749) 10.12 CSRF Protection using non-guessable values in short-lived HTTPS-only cookies to provide reasonable assurance the user in the login phase and callback phase are the same. If you wish to implement this differently, write a `http.Handler` which sets a *state* in the ctx, which is expected by LoginHandler and CallbackHandler.
 
 You may use `oauth2.WithState(context.Context, state string)` for this. [docs](https://godoc.org/github.com/dghubble/gologin/oauth2#WithState)
 
 ### Failure Handlers
 
-If you wish to define your own failure `ContextHandler`, you can get the error from the `ctx` using `gologin.ErrorFromContext(ctx)`.
+If you wish to define your own failure `http.Handler`, you can get the error from the `ctx` using `gologin.ErrorFromContext(ctx)`.
 
 ### Production Requirements
 
@@ -185,7 +175,7 @@ Package `gologin` implements authorization flow steps with chained handlers.
 * Authentication should be orthogonal to the session system. Let users choose their session/token library.
 * OAuth2 State CSRF should be included out of the box, but easy to customize.
 * Packages should import only what is required. OAuth1 and OAuth2 packages are separate.
-* ContextHandlers are flexible and useful for more than just data passing.
+* http.Handlers are flexible and useful for more than just data passing.
 
 Projects [goth](https://github.com/markbates/goth) and [gomniauth](https://github.com/stretchr/gomniauth) aim to provide a similar login solution with a different design. Check them out if you decide you don't like the ideas in `gologin`.
 
@@ -197,7 +187,7 @@ Projects [goth](https://github.com/markbates/goth) and [gomniauth](https://githu
 
 ## Contributing
 
-Contributions are welcome. Improving documentation and examples is a good way to start. New auth providers can be implemented by composing the `oauth1` or `oauth2` ContextHandlers.
+Contributions are welcome. Improving documentation and examples is a good way to start. New auth providers can be implemented by composing the `oauth1` or `oauth2` http.Handlers.
 
 Also, `gologin` aims to use the defacto standard API libraries for User/Account models and verify endpoints. Tumblr and Bitbucket don't seem to have good ones yet. Tiny internal API clients are used.
 
@@ -210,12 +200,12 @@ I originally thought `gologin` should use only `http.Handler` handlers and `hand
 A while ago, some great materials like this Go [blog post](https://blog.golang.org/context), Sameer Ajmani's [Gotham talk](https://vimeo.com/115309491), and Joe Shaw's [article](https://joeshaw.org/net-context-and-http-handler/) helped convince me that 
 
 ```go
-type ContextHandler interface {
+type http.Handler interface {
     ServeHTTP(ctx context.Context, w http.ResponseWriter, req *http.Request)
 }
 ```
 
-is an excellent choice for more advanced handlers. These days I use it a lot.
+is an excellent choice for more advanced handlers. Since Go 1.7, this library has been updated to use context in net/http Request types.
 
 ## License
 

--- a/bitbucket/context.go
+++ b/bitbucket/context.go
@@ -1,9 +1,8 @@
 package bitbucket
 
 import (
+	"context"
 	"fmt"
-
-	"golang.org/x/net/context"
 )
 
 // unexported key type prevents collisions

--- a/bitbucket/context_test.go
+++ b/bitbucket/context_test.go
@@ -1,10 +1,10 @@
 package bitbucket
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 )
 
 func TestContextUser(t *testing.T) {

--- a/bitbucket/login.go
+++ b/bitbucket/login.go
@@ -4,10 +4,8 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/dghubble/ctxh"
 	"github.com/dghubble/gologin"
 	oauth2Login "github.com/dghubble/gologin/oauth2"
-	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 )
 
@@ -24,13 +22,13 @@ var (
 // state params differently, write a ContextHandler which sets the ctx state,
 // using oauth2 WithState(ctx, state) since it is required by LoginHandler
 // and CallbackHandler.
-func StateHandler(config gologin.CookieConfig, success ctxh.ContextHandler) ctxh.ContextHandler {
+func StateHandler(config gologin.CookieConfig, success http.Handler) http.Handler {
 	return oauth2Login.StateHandler(config, success)
 }
 
 // LoginHandler handles Bitbucket login requests by reading the state value
 // from the ctx and redirecting requests to the AuthURL with that state value.
-func LoginHandler(config *oauth2.Config, failure ctxh.ContextHandler) ctxh.ContextHandler {
+func LoginHandler(config *oauth2.Config, failure http.Handler) http.Handler {
 	return oauth2Login.LoginHandler(config, failure)
 }
 
@@ -38,7 +36,7 @@ func LoginHandler(config *oauth2.Config, failure ctxh.ContextHandler) ctxh.Conte
 // Bitbucket access token and User to the ctx. If authentication succeeds,
 // handling delegates to the success handler, otherwise to the failure
 // handler.
-func CallbackHandler(config *oauth2.Config, success, failure ctxh.ContextHandler) ctxh.ContextHandler {
+func CallbackHandler(config *oauth2.Config, success, failure http.Handler) http.Handler {
 	success = bitbucketHandler(config, success, failure)
 	return oauth2Login.CallbackHandler(config, success, failure)
 }
@@ -47,15 +45,16 @@ func CallbackHandler(config *oauth2.Config, success, failure ctxh.ContextHandler
 // to get the corresponding Bitbucket User. If successful, the User is added to
 // the ctx and the success handler is called. Otherwise, the failure handler is
 // called.
-func bitbucketHandler(config *oauth2.Config, success, failure ctxh.ContextHandler) ctxh.ContextHandler {
+func bitbucketHandler(config *oauth2.Config, success, failure http.Handler) http.Handler {
 	if failure == nil {
 		failure = gologin.DefaultFailureHandler
 	}
-	fn := func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	fn := func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
 		token, err := oauth2Login.TokenFromContext(ctx)
 		if err != nil {
 			ctx = gologin.WithError(ctx, err)
-			failure.ServeHTTP(ctx, w, req)
+			failure.ServeHTTP(w, req.WithContext(ctx))
 			return
 		}
 		httpClient := config.Client(ctx, token)
@@ -64,13 +63,13 @@ func bitbucketHandler(config *oauth2.Config, success, failure ctxh.ContextHandle
 		err = validateResponse(user, resp, err)
 		if err != nil {
 			ctx = gologin.WithError(ctx, err)
-			failure.ServeHTTP(ctx, w, req)
+			failure.ServeHTTP(w, req.WithContext(ctx))
 			return
 		}
 		ctx = WithUser(ctx, user)
-		success.ServeHTTP(ctx, w, req)
+		success.ServeHTTP(w, req.WithContext(ctx))
 	}
-	return ctxh.ContextHandlerFunc(fn)
+	return http.HandlerFunc(fn)
 }
 
 // validateResponse returns an error if the given Bitbucket User, raw

--- a/bitbucket/login_test.go
+++ b/bitbucket/login_test.go
@@ -1,17 +1,16 @@
 package bitbucket
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
-	"github.com/dghubble/ctxh"
 	"github.com/dghubble/gologin"
 	oauth2Login "github.com/dghubble/gologin/oauth2"
 	"github.com/dghubble/gologin/testutils"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 )
 
@@ -26,7 +25,8 @@ func TestBitbucketHandler(t *testing.T) {
 	ctx = oauth2Login.WithToken(ctx, anyToken)
 
 	config := &oauth2.Config{}
-	success := func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	success := func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
 		bitbucketUser, err := UserFromContext(ctx)
 		assert.Nil(t, err)
 		assert.Equal(t, expectedUser, bitbucketUser)
@@ -39,17 +39,18 @@ func TestBitbucketHandler(t *testing.T) {
 	// - bitbucket User is obtained from the Bitbucket API
 	// - success handler is called
 	// - bitbucket User is added to the ctx of the success handler
-	bitbucketHandler := bitbucketHandler(config, ctxh.ContextHandlerFunc(success), failure)
+	bitbucketHandler := bitbucketHandler(config, http.HandlerFunc(success), failure)
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/", nil)
-	bitbucketHandler.ServeHTTP(ctx, w, req)
+	bitbucketHandler.ServeHTTP(w, req.WithContext(ctx))
 	assert.Equal(t, "success handler called", w.Body.String())
 }
 
 func TestBitbucketHandler_MissingCtxToken(t *testing.T) {
 	config := &oauth2.Config{}
 	success := testutils.AssertSuccessNotCalled(t)
-	failure := func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	failure := func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
 		err := gologin.ErrorFromContext(ctx)
 		if assert.NotNil(t, err) {
 			assert.Equal(t, "oauth2: Context missing Token", err.Error())
@@ -60,10 +61,10 @@ func TestBitbucketHandler_MissingCtxToken(t *testing.T) {
 	// BitbucketHandler called without Token in ctx, assert that:
 	// - failure handler is called
 	// - error about ctx missing token is added to the failure handler ctx
-	bitbucketHandler := bitbucketHandler(config, success, ctxh.ContextHandlerFunc(failure))
+	bitbucketHandler := bitbucketHandler(config, success, http.HandlerFunc(failure))
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/", nil)
-	bitbucketHandler.ServeHTTP(context.Background(), w, req)
+	bitbucketHandler.ServeHTTP(w, req)
 	assert.Equal(t, "failure handler called", w.Body.String())
 }
 
@@ -77,7 +78,8 @@ func TestBitbucketHandler_ErrorGettingUser(t *testing.T) {
 
 	config := &oauth2.Config{}
 	success := testutils.AssertSuccessNotCalled(t)
-	failure := func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	failure := func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
 		err := gologin.ErrorFromContext(ctx)
 		if assert.NotNil(t, err) {
 			assert.Equal(t, ErrUnableToGetBitbucketUser, err)
@@ -88,10 +90,10 @@ func TestBitbucketHandler_ErrorGettingUser(t *testing.T) {
 	// BitbucketHandler cannot get Bitbucket User, assert that:
 	// - failure handler is called
 	// - error cannot get Bitbucket User added to the failure handler ctx
-	bitbucketHandler := bitbucketHandler(config, success, ctxh.ContextHandlerFunc(failure))
+	bitbucketHandler := bitbucketHandler(config, success, http.HandlerFunc(failure))
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/", nil)
-	bitbucketHandler.ServeHTTP(ctx, w, req)
+	bitbucketHandler.ServeHTTP(w, req.WithContext(ctx))
 	assert.Equal(t, "failure handler called", w.Body.String())
 }
 

--- a/context.go
+++ b/context.go
@@ -1,9 +1,8 @@
 package gologin
 
 import (
+	"context"
 	"fmt"
-
-	"golang.org/x/net/context"
 )
 
 // unexported key type prevents collisions

--- a/context_test.go
+++ b/context_test.go
@@ -1,11 +1,11 @@
 package gologin
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 )
 
 func TestContextError(t *testing.T) {

--- a/digits/context.go
+++ b/digits/context.go
@@ -1,10 +1,10 @@
 package digits
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/dghubble/go-digits/digits"
-	"golang.org/x/net/context"
 )
 
 // unexported key type prevents collisions

--- a/digits/login.go
+++ b/digits/login.go
@@ -6,11 +6,9 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/dghubble/ctxh"
 	"github.com/dghubble/go-digits/digits"
 	"github.com/dghubble/gologin"
 	"github.com/dghubble/sling"
-	"golang.org/x/net/context"
 )
 
 const (
@@ -41,15 +39,16 @@ type Config struct {
 // validates the echo, and calls the endpoint to get the corresponding Digits
 // Account. If successful, the Digits Account is added to the ctx and the
 // success handler is called. Otherwise, the failure handler is called.
-func LoginHandler(config *Config, success, failure ctxh.ContextHandler) ctxh.ContextHandler {
+func LoginHandler(config *Config, success, failure http.Handler) http.Handler {
 	success = getAccountViaEcho(config, success, failure)
 	if failure == nil {
 		failure = gologin.DefaultFailureHandler
 	}
-	fn := func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	fn := func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
 		if req.Method != "POST" {
 			ctx = gologin.WithError(ctx, fmt.Errorf("Method not allowed"))
-			failure.ServeHTTP(ctx, w, req)
+			failure.ServeHTTP(w, req.WithContext(ctx))
 			return
 		}
 		req.ParseForm()
@@ -59,20 +58,20 @@ func LoginHandler(config *Config, success, failure ctxh.ContextHandler) ctxh.Con
 		err := validateEcho(accountEndpoint, accountRequestHeader, config.ConsumerKey)
 		if err != nil {
 			ctx = gologin.WithError(ctx, err)
-			failure.ServeHTTP(ctx, w, req)
+			failure.ServeHTTP(w, req.WithContext(ctx))
 			return
 		}
 		ctx = WithEcho(ctx, accountEndpoint, accountRequestHeader)
-		success.ServeHTTP(ctx, w, req)
+		success.ServeHTTP(w, req.WithContext(ctx))
 	}
-	return ctxh.ContextHandlerFunc(fn)
+	return http.HandlerFunc(fn)
 }
 
 // getAccountViaEcho is a ContextHandler that gets the Digits Echo endpoint and
 // OAuth header from the ctx and calls the endpoint to get the corresponding
 // Digits Account. If successful, the Account is added to the ctx and the
 // success handler is called. Otherwise, the failure handler is called.
-func getAccountViaEcho(config *Config, success, failure ctxh.ContextHandler) ctxh.ContextHandler {
+func getAccountViaEcho(config *Config, success, failure http.Handler) http.Handler {
 	if failure == nil {
 		failure = gologin.DefaultFailureHandler
 	}
@@ -80,11 +79,12 @@ func getAccountViaEcho(config *Config, success, failure ctxh.ContextHandler) ctx
 	if client == nil {
 		client = http.DefaultClient
 	}
-	fn := func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	fn := func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
 		endpoint, header, err := EchoFromContext(ctx)
 		if err != nil {
 			ctx = gologin.WithError(ctx, err)
-			failure.ServeHTTP(ctx, w, req)
+			failure.ServeHTTP(w, req.WithContext(ctx))
 			return
 		}
 		// fetch the Digits Account
@@ -93,13 +93,13 @@ func getAccountViaEcho(config *Config, success, failure ctxh.ContextHandler) ctx
 		err = validateResponse(account, resp, err)
 		if err != nil {
 			ctx = gologin.WithError(ctx, err)
-			failure.ServeHTTP(ctx, w, req)
+			failure.ServeHTTP(w, req.WithContext(ctx))
 			return
 		}
 		ctx = WithAccount(ctx, account)
-		success.ServeHTTP(ctx, w, req)
+		success.ServeHTTP(w, req.WithContext(ctx))
 	}
-	return ctxh.ContextHandlerFunc(fn)
+	return http.HandlerFunc(fn)
 }
 
 // validateEcho checks that the Digits OAuth Echo arguments are valid. If the

--- a/digits/token.go
+++ b/digits/token.go
@@ -4,12 +4,10 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/dghubble/ctxh"
 	"github.com/dghubble/go-digits/digits"
 	"github.com/dghubble/gologin"
 	oauth1Login "github.com/dghubble/gologin/oauth1"
 	"github.com/dghubble/oauth1"
-	"golang.org/x/net/context"
 )
 
 const (
@@ -27,15 +25,16 @@ var (
 // accounts endpoint to get the corresponding Account. If successful, the
 // access token/secret and Account are added to the ctx and the success handler
 // is called. Otherwise, the failure handler is called.
-func TokenHandler(config *oauth1.Config, success, failure ctxh.ContextHandler) ctxh.ContextHandler {
+func TokenHandler(config *oauth1.Config, success, failure http.Handler) http.Handler {
 	success = digitsHandler(config, success, failure)
 	if failure == nil {
 		failure = gologin.DefaultFailureHandler
 	}
-	fn := func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	fn := func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
 		if req.Method != "POST" {
 			ctx = gologin.WithError(ctx, fmt.Errorf("Method not allowed"))
-			failure.ServeHTTP(ctx, w, req)
+			failure.ServeHTTP(w, req.WithContext(ctx))
 			return
 		}
 		req.ParseForm()
@@ -44,28 +43,29 @@ func TokenHandler(config *oauth1.Config, success, failure ctxh.ContextHandler) c
 		err := validateToken(accessToken, accessSecret)
 		if err != nil {
 			ctx = gologin.WithError(ctx, err)
-			failure.ServeHTTP(ctx, w, req)
+			failure.ServeHTTP(w, req.WithContext(ctx))
 			return
 		}
 		ctx = oauth1Login.WithAccessToken(ctx, accessToken, accessSecret)
-		success.ServeHTTP(ctx, w, req)
+		success.ServeHTTP(w, req.WithContext(ctx))
 	}
-	return ctxh.ContextHandlerFunc(fn)
+	return http.HandlerFunc(fn)
 }
 
 // digitsHandler is a ContextHandler that gets the OAuth1 access token from the
 // ctx and calls the Digits accounts endpoint to get the corresponding Account.
 // If successful, the Account is added to the ctx and the success handler is
 // called. Otherwise, the failure handler is called.
-func digitsHandler(config *oauth1.Config, success, failure ctxh.ContextHandler) ctxh.ContextHandler {
+func digitsHandler(config *oauth1.Config, success, failure http.Handler) http.Handler {
 	if failure == nil {
 		failure = gologin.DefaultFailureHandler
 	}
-	fn := func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	fn := func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
 		accessToken, accessSecret, err := oauth1Login.AccessTokenFromContext(ctx)
 		if err != nil {
 			ctx = gologin.WithError(ctx, err)
-			failure.ServeHTTP(ctx, w, req)
+			failure.ServeHTTP(w, req.WithContext(ctx))
 			return
 		}
 		httpClient := config.Client(ctx, oauth1.NewToken(accessToken, accessSecret))
@@ -74,13 +74,13 @@ func digitsHandler(config *oauth1.Config, success, failure ctxh.ContextHandler) 
 		err = validateResponse(account, resp, err)
 		if err != nil {
 			ctx = gologin.WithError(ctx, err)
-			failure.ServeHTTP(ctx, w, req)
+			failure.ServeHTTP(w, req.WithContext(ctx))
 			return
 		}
 		ctx = WithAccount(ctx, account)
-		success.ServeHTTP(ctx, w, req)
+		success.ServeHTTP(w, req.WithContext(ctx))
 	}
-	return ctxh.ContextHandlerFunc(fn)
+	return http.HandlerFunc(fn)
 }
 
 // validateToken returns an error if the token or token secret is missing.

--- a/digits/token_test.go
+++ b/digits/token_test.go
@@ -6,12 +6,10 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/dghubble/ctxh"
 	oauth1Login "github.com/dghubble/gologin/oauth1"
 	"github.com/dghubble/gologin/testutils"
 	"github.com/dghubble/oauth1"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 )
 
 func TestValidateToken_missingToken(t *testing.T) {
@@ -31,11 +29,10 @@ func TestValidateToken_missingTokenSecret(t *testing.T) {
 func TestTokenHandler(t *testing.T) {
 	proxyClient, _, server := newDigitsTestServer(testAccountJSON)
 	defer server.Close()
-	// oauth1 Client will use the proxy client's base Transport
-	ctx := context.WithValue(context.Background(), oauth1.HTTPClient, proxyClient)
 
 	config := &oauth1.Config{}
-	success := func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	success := func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
 		account, err := AccountFromContext(ctx)
 		assert.Nil(t, err)
 		assert.Equal(t, testDigitsToken, account.AccessToken.Token)
@@ -47,8 +44,9 @@ func TestTokenHandler(t *testing.T) {
 		assert.Equal(t, testDigitsToken, accessToken)
 		assert.Equal(t, testDigitsSecret, accessSecret)
 	}
-	handler := TokenHandler(config, ctxh.ContextHandlerFunc(success), testutils.AssertFailureNotCalled(t))
-	ts := httptest.NewServer(ctxh.NewHandlerWithContext(ctx, handler))
+	handler := TokenHandler(config, http.HandlerFunc(success), testutils.AssertFailureNotCalled(t))
+	// oauth1 Client will use the proxy client's base Transport
+	ts := httptest.NewServer(oauth1Login.WithHTTPClient(proxyClient, handler))
 	// POST Digits access token to server under test
 	resp, err := http.PostForm(ts.URL, url.Values{accessTokenField: {testDigitsToken}, accessTokenSecretField: {testDigitsSecret}})
 	assert.Nil(t, err)
@@ -60,12 +58,11 @@ func TestTokenHandler(t *testing.T) {
 func TestTokenHandler_ErrorVerifyingToken(t *testing.T) {
 	proxyClient, server := testutils.NewErrorServer("Digits Account Endpoint Down", http.StatusInternalServerError)
 	defer server.Close()
-	// oauth1 Client will use the proxy client's base Transport
-	ctx := context.WithValue(context.Background(), oauth1.HTTPClient, proxyClient)
 
 	config := &oauth1.Config{}
 	handler := TokenHandler(config, testutils.AssertSuccessNotCalled(t), nil)
-	ts := httptest.NewServer(ctxh.NewHandlerWithContext(ctx, handler))
+	// oauth1 Client will use the proxy client's base Transport
+	ts := httptest.NewServer(oauth1Login.WithHTTPClient(proxyClient, handler))
 	// assert that error occurs indicating the Digits Account could not be confirmed
 	resp, _ := http.PostForm(ts.URL, url.Values{accessTokenField: {testDigitsToken}, accessTokenSecretField: {testDigitsSecret}})
 	testutils.AssertBodyString(t, resp.Body, ErrUnableToGetDigitsAccount.Error()+"\n")
@@ -74,7 +71,7 @@ func TestTokenHandler_ErrorVerifyingToken(t *testing.T) {
 func TestTokenHandler_NonPost(t *testing.T) {
 	config := &oauth1.Config{}
 	handler := TokenHandler(config, testutils.AssertSuccessNotCalled(t), nil)
-	ts := httptest.NewServer(ctxh.NewHandler(handler))
+	ts := httptest.NewServer(handler)
 	resp, err := http.Get(ts.URL)
 	assert.Nil(t, err)
 	// assert that default (nil) failure handler returns a 405 Method Not Allowed
@@ -87,7 +84,7 @@ func TestTokenHandler_NonPost(t *testing.T) {
 func TestTokenHandler_InvalidFields(t *testing.T) {
 	config := &oauth1.Config{}
 	handler := TokenHandler(config, testutils.AssertSuccessNotCalled(t), nil)
-	ts := httptest.NewServer(ctxh.NewHandler(handler))
+	ts := httptest.NewServer(handler)
 
 	// asert errors occur for different missing POST fields
 	resp, err := http.PostForm(ts.URL, url.Values{"wrongFieldName": {testDigitsToken}, accessTokenSecretField: {testDigitsSecret}})

--- a/errors.go
+++ b/errors.go
@@ -2,16 +2,14 @@ package gologin
 
 import (
 	"net/http"
-
-	"github.com/dghubble/ctxh"
-	"golang.org/x/net/context"
 )
 
 // DefaultFailureHandler responds with a 400 status code and message parsed
 // from the ctx.
-var DefaultFailureHandler = ctxh.ContextHandlerFunc(failureHandler)
+var DefaultFailureHandler = http.HandlerFunc(failureHandler)
 
-func failureHandler(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+func failureHandler(w http.ResponseWriter, req *http.Request) {
+	ctx := req.Context()
 	err := ErrorFromContext(ctx)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,13 +1,13 @@
 package gologin
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 )
 
 func TestDefaultFailureHandler(t *testing.T) {
@@ -16,7 +16,7 @@ func TestDefaultFailureHandler(t *testing.T) {
 	req, err := http.NewRequest("GET", "/", nil)
 	assert.Nil(t, err)
 	w := httptest.NewRecorder()
-	DefaultFailureHandler.ServeHTTP(ctx, w, req)
+	DefaultFailureHandler.ServeHTTP(w, req.WithContext(ctx))
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	// assert that error message was passed through
 	assert.Equal(t, expectedError.Error()+"\n", w.Body.String())

--- a/facebook/context.go
+++ b/facebook/context.go
@@ -1,9 +1,8 @@
 package facebook
 
 import (
+	"context"
 	"fmt"
-
-	"golang.org/x/net/context"
 )
 
 // unexported key type prevents collisions

--- a/facebook/context_test.go
+++ b/facebook/context_test.go
@@ -1,10 +1,10 @@
 package facebook
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 )
 
 func TestContextUser(t *testing.T) {

--- a/facebook/login.go
+++ b/facebook/login.go
@@ -4,10 +4,8 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/dghubble/ctxh"
 	"github.com/dghubble/gologin"
 	oauth2Login "github.com/dghubble/gologin/oauth2"
-	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 )
 
@@ -24,13 +22,13 @@ var (
 // state params differently, write a ContextHandler which sets the ctx state,
 // using oauth2 WithState(ctx, state) since it is required by LoginHandler
 // and CallbackHandler.
-func StateHandler(config gologin.CookieConfig, success ctxh.ContextHandler) ctxh.ContextHandler {
+func StateHandler(config gologin.CookieConfig, success http.Handler) http.Handler {
 	return oauth2Login.StateHandler(config, success)
 }
 
 // LoginHandler handles Facebook login requests by reading the state value
 // from the ctx and redirecting requests to the AuthURL with that state value.
-func LoginHandler(config *oauth2.Config, failure ctxh.ContextHandler) ctxh.ContextHandler {
+func LoginHandler(config *oauth2.Config, failure http.Handler) http.Handler {
 	return oauth2Login.LoginHandler(config, failure)
 }
 
@@ -38,7 +36,7 @@ func LoginHandler(config *oauth2.Config, failure ctxh.ContextHandler) ctxh.Conte
 // Facebook access token and User to the ctx. If authentication succeeds,
 // handling delegates to the success handler, otherwise to the failure
 // handler.
-func CallbackHandler(config *oauth2.Config, success, failure ctxh.ContextHandler) ctxh.ContextHandler {
+func CallbackHandler(config *oauth2.Config, success, failure http.Handler) http.Handler {
 	success = facebookHandler(config, success, failure)
 	return oauth2Login.CallbackHandler(config, success, failure)
 }
@@ -47,15 +45,16 @@ func CallbackHandler(config *oauth2.Config, success, failure ctxh.ContextHandler
 // to get the corresponding Facebook User. If successful, the user is added to
 // the ctx and the success handler is called. Otherwise, the failure handler
 // is called.
-func facebookHandler(config *oauth2.Config, success, failure ctxh.ContextHandler) ctxh.ContextHandler {
+func facebookHandler(config *oauth2.Config, success, failure http.Handler) http.Handler {
 	if failure == nil {
 		failure = gologin.DefaultFailureHandler
 	}
-	fn := func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	fn := func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
 		token, err := oauth2Login.TokenFromContext(ctx)
 		if err != nil {
 			ctx = gologin.WithError(ctx, err)
-			failure.ServeHTTP(ctx, w, req)
+			failure.ServeHTTP(w, req.WithContext(ctx))
 			return
 		}
 		httpClient := config.Client(ctx, token)
@@ -64,13 +63,13 @@ func facebookHandler(config *oauth2.Config, success, failure ctxh.ContextHandler
 		err = validateResponse(user, resp, err)
 		if err != nil {
 			ctx = gologin.WithError(ctx, err)
-			failure.ServeHTTP(ctx, w, req)
+			failure.ServeHTTP(w, req.WithContext(ctx))
 			return
 		}
 		ctx = WithUser(ctx, user)
-		success.ServeHTTP(ctx, w, req)
+		success.ServeHTTP(w, req.WithContext(ctx))
 	}
-	return ctxh.ContextHandlerFunc(fn)
+	return http.HandlerFunc(fn)
 }
 
 // validateResponse returns an error if the given Facebook User, raw

--- a/github/context.go
+++ b/github/context.go
@@ -1,10 +1,10 @@
 package github
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/google/go-github/github"
-	"golang.org/x/net/context"
 )
 
 // unexported key type prevents collisions

--- a/github/context_test.go
+++ b/github/context_test.go
@@ -1,11 +1,11 @@
 package github
 
 import (
+	"context"
 	"testing"
 
 	"github.com/google/go-github/github"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 )
 
 func TestContextUser(t *testing.T) {

--- a/github/login.go
+++ b/github/login.go
@@ -4,11 +4,9 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/dghubble/ctxh"
 	"github.com/dghubble/gologin"
 	oauth2Login "github.com/dghubble/gologin/oauth2"
 	"github.com/google/go-github/github"
-	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 )
 
@@ -25,20 +23,20 @@ var (
 // state params differently, write a ContextHandler which sets the ctx state,
 // using oauth2 WithState(ctx, state) since it is required by LoginHandler
 // and CallbackHandler.
-func StateHandler(config gologin.CookieConfig, success ctxh.ContextHandler) ctxh.ContextHandler {
+func StateHandler(config gologin.CookieConfig, success http.Handler) http.Handler {
 	return oauth2Login.StateHandler(config, success)
 }
 
 // LoginHandler handles Github login requests by reading the state value from
 // the ctx and redirecting requests to the AuthURL with that state value.
-func LoginHandler(config *oauth2.Config, failure ctxh.ContextHandler) ctxh.ContextHandler {
+func LoginHandler(config *oauth2.Config, failure http.Handler) http.Handler {
 	return oauth2Login.LoginHandler(config, failure)
 }
 
 // CallbackHandler handles Github redirection URI requests and adds the Github
 // access token and User to the ctx. If authentication succeeds, handling
 // delegates to the success handler, otherwise to the failure handler.
-func CallbackHandler(config *oauth2.Config, success, failure ctxh.ContextHandler) ctxh.ContextHandler {
+func CallbackHandler(config *oauth2.Config, success, failure http.Handler) http.Handler {
 	success = githubHandler(config, success, failure)
 	return oauth2Login.CallbackHandler(config, success, failure)
 }
@@ -47,15 +45,16 @@ func CallbackHandler(config *oauth2.Config, success, failure ctxh.ContextHandler
 // get the corresponding Github User. If successful, the User is added to the
 // ctx and the success handler is called. Otherwise, the failure handler is
 // called.
-func githubHandler(config *oauth2.Config, success, failure ctxh.ContextHandler) ctxh.ContextHandler {
+func githubHandler(config *oauth2.Config, success, failure http.Handler) http.Handler {
 	if failure == nil {
 		failure = gologin.DefaultFailureHandler
 	}
-	fn := func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	fn := func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
 		token, err := oauth2Login.TokenFromContext(ctx)
 		if err != nil {
 			ctx = gologin.WithError(ctx, err)
-			failure.ServeHTTP(ctx, w, req)
+			failure.ServeHTTP(w, req.WithContext(ctx))
 			return
 		}
 		httpClient := config.Client(ctx, token)
@@ -64,13 +63,13 @@ func githubHandler(config *oauth2.Config, success, failure ctxh.ContextHandler) 
 		err = validateResponse(user, resp, err)
 		if err != nil {
 			ctx = gologin.WithError(ctx, err)
-			failure.ServeHTTP(ctx, w, req)
+			failure.ServeHTTP(w, req.WithContext(ctx))
 			return
 		}
 		ctx = WithUser(ctx, user)
-		success.ServeHTTP(ctx, w, req)
+		success.ServeHTTP(w, req.WithContext(ctx))
 	}
-	return ctxh.ContextHandlerFunc(fn)
+	return http.HandlerFunc(fn)
 }
 
 // validateResponse returns an error if the given Github user, raw

--- a/google/context.go
+++ b/google/context.go
@@ -1,9 +1,9 @@
 package google
 
 import (
+	"context"
 	"fmt"
 
-	"golang.org/x/net/context"
 	google "google.golang.org/api/oauth2/v2"
 )
 

--- a/google/context_test.go
+++ b/google/context_test.go
@@ -1,10 +1,10 @@
 package google
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 	google "google.golang.org/api/oauth2/v2"
 )
 

--- a/google/login_test.go
+++ b/google/login_test.go
@@ -1,17 +1,16 @@
 package google
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
-	"github.com/dghubble/ctxh"
 	"github.com/dghubble/gologin"
 	oauth2Login "github.com/dghubble/gologin/oauth2"
 	"github.com/dghubble/gologin/testutils"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 	google "google.golang.org/api/oauth2/v2"
 )
@@ -27,7 +26,8 @@ func TestGoogleHandler(t *testing.T) {
 	ctx = oauth2Login.WithToken(ctx, anyToken)
 
 	config := &oauth2.Config{}
-	success := func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	success := func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
 		googleUser, err := UserFromContext(ctx)
 		assert.Nil(t, err)
 		// assert required fields; Userinfoplus contains other raw response info
@@ -42,17 +42,18 @@ func TestGoogleHandler(t *testing.T) {
 	// - google Userinfoplus is obtained from the Google API
 	// - success handler is called
 	// - google Userinfoplus is added to the ctx of the success handler
-	googleHandler := googleHandler(config, ctxh.ContextHandlerFunc(success), failure)
+	googleHandler := googleHandler(config, http.HandlerFunc(success), failure)
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/", nil)
-	googleHandler.ServeHTTP(ctx, w, req)
+	googleHandler.ServeHTTP(w, req.WithContext(ctx))
 	assert.Equal(t, "success handler called", w.Body.String())
 }
 
 func TestGoogleHandler_MissingCtxToken(t *testing.T) {
 	config := &oauth2.Config{}
 	success := testutils.AssertSuccessNotCalled(t)
-	failure := func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	failure := func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
 		err := gologin.ErrorFromContext(ctx)
 		if assert.NotNil(t, err) {
 			assert.Equal(t, "oauth2: Context missing Token", err.Error())
@@ -63,10 +64,10 @@ func TestGoogleHandler_MissingCtxToken(t *testing.T) {
 	// GoogleHandler called without Token in ctx, assert that:
 	// - failure handler is called
 	// - error about ctx missing token is added to the failure handler ctx
-	googleHandler := googleHandler(config, success, ctxh.ContextHandlerFunc(failure))
+	googleHandler := googleHandler(config, success, http.HandlerFunc(failure))
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/", nil)
-	googleHandler.ServeHTTP(context.Background(), w, req)
+	googleHandler.ServeHTTP(w, req)
 	assert.Equal(t, "failure handler called", w.Body.String())
 }
 
@@ -80,7 +81,8 @@ func TestGoogleHandler_ErrorGettingUser(t *testing.T) {
 
 	config := &oauth2.Config{}
 	success := testutils.AssertSuccessNotCalled(t)
-	failure := func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	failure := func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
 		err := gologin.ErrorFromContext(ctx)
 		if assert.NotNil(t, err) {
 			assert.Equal(t, ErrUnableToGetGoogleUser, err)
@@ -91,10 +93,10 @@ func TestGoogleHandler_ErrorGettingUser(t *testing.T) {
 	// GoogleHandler cannot get Google User, assert that:
 	// - failure handler is called
 	// - error cannot get Google User added to the failure handler ctx
-	googleHandler := googleHandler(config, success, ctxh.ContextHandlerFunc(failure))
+	googleHandler := googleHandler(config, success, http.HandlerFunc(failure))
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/", nil)
-	googleHandler.ServeHTTP(ctx, w, req)
+	googleHandler.ServeHTTP(w, req.WithContext(ctx))
 	assert.Equal(t, "failure handler called", w.Body.String())
 }
 

--- a/oauth1/context.go
+++ b/oauth1/context.go
@@ -1,9 +1,11 @@
 package oauth1
 
 import (
+	"context"
 	"fmt"
+	"net/http"
 
-	"golang.org/x/net/context"
+	olib "github.com/dghubble/oauth1"
 )
 
 // unexported key type prevents collisions
@@ -50,4 +52,12 @@ func AccessTokenFromContext(ctx context.Context) (string, string, error) {
 		return "", "", fmt.Errorf("oauth1: Context missing access token or secret")
 	}
 	return accessToken, accessSecret, nil
+}
+
+// WithHTTPClient returns a handler that sets the provided HttpClient in the request context.
+func WithHTTPClient(client *http.Client, next http.Handler) http.Handler {
+	fn := func(w http.ResponseWriter, req *http.Request) {
+		next.ServeHTTP(w, req.WithContext(context.WithValue(req.Context(), olib.HTTPClient, client)))
+	}
+	return http.HandlerFunc(fn)
 }

--- a/oauth1/context_test.go
+++ b/oauth1/context_test.go
@@ -1,10 +1,10 @@
 package oauth1
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 )
 
 func TestContextRequestToken(t *testing.T) {

--- a/oauth2/context.go
+++ b/oauth2/context.go
@@ -1,9 +1,9 @@
 package oauth2
 
 import (
+	"context"
 	"fmt"
 
-	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 )
 

--- a/oauth2/context_test.go
+++ b/oauth2/context_test.go
@@ -1,10 +1,10 @@
 package oauth2
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 )
 

--- a/testutils/asserts.go
+++ b/testutils/asserts.go
@@ -7,25 +7,23 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/dghubble/ctxh"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 )
 
 // AssertSuccessNotCalled is a success ContextHandler that fails if called.
-func AssertSuccessNotCalled(t *testing.T) ctxh.ContextHandler {
-	fn := func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+func AssertSuccessNotCalled(t *testing.T) http.Handler {
+	fn := func(w http.ResponseWriter, req *http.Request) {
 		assert.Fail(t, "unexpected call to success ContextHandler")
 	}
-	return ctxh.ContextHandlerFunc(fn)
+	return http.HandlerFunc(fn)
 }
 
 // AssertFailureNotCalled is a failure ContextHandler that fails if called.
-func AssertFailureNotCalled(t *testing.T) ctxh.ContextHandler {
-	fn := func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+func AssertFailureNotCalled(t *testing.T) http.Handler {
+	fn := func(w http.ResponseWriter, req *http.Request) {
 		assert.Fail(t, "unexpected call to failure ContextHandler")
 	}
-	return ctxh.ContextHandlerFunc(fn)
+	return http.HandlerFunc(fn)
 }
 
 // AssertBodyString asserts that a Request Body matches the expected string.

--- a/tumblr/context.go
+++ b/tumblr/context.go
@@ -1,9 +1,8 @@
 package tumblr
 
 import (
+	"context"
 	"fmt"
-
-	"golang.org/x/net/context"
 )
 
 // unexported key type prevents collisions

--- a/tumblr/login.go
+++ b/tumblr/login.go
@@ -4,11 +4,9 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/dghubble/ctxh"
 	"github.com/dghubble/gologin"
 	oauth1Login "github.com/dghubble/gologin/oauth1"
 	"github.com/dghubble/oauth1"
-	"golang.org/x/net/context"
 )
 
 // Tumblr login errors
@@ -19,7 +17,7 @@ var (
 // LoginHandler handles Tumblr login requests by obtaining a request token,
 // setting a temporary token secret cookie, and redirecting to the
 // authorization URL.
-func LoginHandler(config *oauth1.Config, cookieConfig gologin.CookieConfig, failure ctxh.ContextHandler) ctxh.ContextHandler {
+func LoginHandler(config *oauth1.Config, cookieConfig gologin.CookieConfig, failure http.Handler) http.Handler {
 	// oauth1.LoginHandler -> oauth1.CookieTempHander -> oauth1.AuthRedirectHandler
 	success := oauth1Login.AuthRedirectHandler(config, failure)
 	success = oauth1Login.CookieTempHandler(cookieConfig, success, failure)
@@ -30,7 +28,7 @@ func LoginHandler(config *oauth1.Config, cookieConfig gologin.CookieConfig, fail
 // and verifier and adding the Tubmlr access token and User to the ctx. If
 // authentication succeeds, handling delegates to the success handler,
 // otherwise to the failure handler.
-func CallbackHandler(config *oauth1.Config, cookieConfig gologin.CookieConfig, success, failure ctxh.ContextHandler) ctxh.ContextHandler {
+func CallbackHandler(config *oauth1.Config, cookieConfig gologin.CookieConfig, success, failure http.Handler) http.Handler {
 	// oauth1.CookieTempHandler -> oauth1.CallbackHandler -> TumblrHandler -> success
 	success = tumblrHandler(config, success, failure)
 	success = oauth1Login.CallbackHandler(config, success, failure)
@@ -41,15 +39,16 @@ func CallbackHandler(config *oauth1.Config, cookieConfig gologin.CookieConfig, s
 // the ctx and obtains the Tumblr User. If successful, the User is added to
 // the ctx and the success handler is called. Otherwise, the failure handler
 // is called.
-func tumblrHandler(config *oauth1.Config, success, failure ctxh.ContextHandler) ctxh.ContextHandler {
+func tumblrHandler(config *oauth1.Config, success, failure http.Handler) http.Handler {
 	if failure == nil {
 		failure = gologin.DefaultFailureHandler
 	}
-	fn := func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	fn := func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
 		accessToken, accessSecret, err := oauth1Login.AccessTokenFromContext(ctx)
 		if err != nil {
 			ctx = gologin.WithError(ctx, err)
-			failure.ServeHTTP(ctx, w, req)
+			failure.ServeHTTP(w, req.WithContext(ctx))
 			return
 		}
 		httpClient := config.Client(ctx, oauth1.NewToken(accessToken, accessSecret))
@@ -58,13 +57,13 @@ func tumblrHandler(config *oauth1.Config, success, failure ctxh.ContextHandler) 
 		err = validateResponse(user, resp, err)
 		if err != nil {
 			ctx = gologin.WithError(ctx, err)
-			failure.ServeHTTP(ctx, w, req)
+			failure.ServeHTTP(w, req.WithContext(ctx))
 			return
 		}
 		ctx = WithUser(ctx, user)
-		success.ServeHTTP(ctx, w, req)
+		success.ServeHTTP(w, req.WithContext(ctx))
 	}
-	return ctxh.ContextHandlerFunc(fn)
+	return http.HandlerFunc(fn)
 }
 
 // validateResponse returns an error if the given Tumblr User, raw

--- a/twitter/context.go
+++ b/twitter/context.go
@@ -1,10 +1,10 @@
 package twitter
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/dghubble/go-twitter/twitter"
-	"golang.org/x/net/context"
 )
 
 // unexported key type prevents collisions

--- a/twitter/token_test.go
+++ b/twitter/token_test.go
@@ -7,13 +7,11 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/dghubble/ctxh"
 	"github.com/dghubble/gologin"
 	oauth1Login "github.com/dghubble/gologin/oauth1"
 	"github.com/dghubble/gologin/testutils"
 	"github.com/dghubble/oauth1"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 )
 
 const (
@@ -26,11 +24,10 @@ const (
 func TestTokenHandler(t *testing.T) {
 	proxyClient, _, server := newTwitterVerifyServer(testTwitterUserJSON)
 	defer server.Close()
-	// oauth1 Client will use the proxy client's base Transport
-	ctx := context.WithValue(context.Background(), oauth1.HTTPClient, proxyClient)
 
 	config := &oauth1.Config{}
-	success := func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	success := func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
 		accessToken, accessSecret, err := oauth1Login.AccessTokenFromContext(ctx)
 		assert.Nil(t, err)
 		assert.Equal(t, testTwitterToken, accessToken)
@@ -41,8 +38,9 @@ func TestTokenHandler(t *testing.T) {
 		assert.Equal(t, expectedUserID, user.ID)
 		assert.Equal(t, "1234", user.IDStr)
 	}
-	handler := TokenHandler(config, ctxh.ContextHandlerFunc(success), testutils.AssertFailureNotCalled(t))
-	ts := httptest.NewServer(ctxh.NewHandlerWithContext(ctx, handler))
+	handler := TokenHandler(config, http.HandlerFunc(success), testutils.AssertFailureNotCalled(t))
+	// oauth1 Client will use the proxy client's base Transport
+	ts := httptest.NewServer(oauth1Login.WithHTTPClient(proxyClient, handler))
 	// POST token to server under test
 	resp, err := http.PostForm(ts.URL, url.Values{accessTokenField: {testTwitterToken}, accessTokenSecretField: {testTwitterTokenSecret}})
 	assert.Nil(t, err)
@@ -54,12 +52,11 @@ func TestTokenHandler(t *testing.T) {
 func TestTokenHandler_ErrorVerifyingToken(t *testing.T) {
 	proxyClient, server := testutils.NewErrorServer("Twitter Verify Credentials Down", http.StatusInternalServerError)
 	defer server.Close()
-	// oauth1 Client will use the proxy client's base Transport
-	ctx := context.WithValue(context.Background(), oauth1.HTTPClient, proxyClient)
 
 	config := &oauth1.Config{}
 	handler := TokenHandler(config, testutils.AssertSuccessNotCalled(t), nil)
-	ts := httptest.NewServer(ctxh.NewHandlerWithContext(ctx, handler))
+	// oauth1 Client will use the proxy client's base Transport
+	ts := httptest.NewServer(oauth1Login.WithHTTPClient(proxyClient, handler))
 	// assert that error occurs indicating the Twitter User could not be confirmed
 	resp, _ := http.PostForm(ts.URL, url.Values{accessTokenField: {testTwitterToken}, accessTokenSecretField: {testTwitterTokenSecret}})
 	testutils.AssertBodyString(t, resp.Body, ErrUnableToGetTwitterUser.Error()+"\n")
@@ -68,25 +65,25 @@ func TestTokenHandler_ErrorVerifyingToken(t *testing.T) {
 func TestTokenHandler_ErrorVerifyingTokenPassesError(t *testing.T) {
 	proxyClient, server := testutils.NewErrorServer("Twitter Verify Credentials Down", http.StatusInternalServerError)
 	defer server.Close()
-	// oauth1 Client will use the proxy client's base Transport
-	ctx := context.WithValue(context.Background(), oauth1.HTTPClient, proxyClient)
 
 	config := &oauth1.Config{}
-	failure := func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	failure := func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
 		// assert that error passed through ctx
 		err := gologin.ErrorFromContext(ctx)
 		if assert.Error(t, err) {
 			assert.Equal(t, err, ErrUnableToGetTwitterUser)
 		}
 	}
-	handler := TokenHandler(config, testutils.AssertSuccessNotCalled(t), ctxh.ContextHandlerFunc(failure))
-	ts := httptest.NewServer(ctxh.NewHandlerWithContext(ctx, handler))
+	handler := TokenHandler(config, testutils.AssertSuccessNotCalled(t), http.HandlerFunc(failure))
+	// oauth1 Client will use the proxy client's base Transport
+	ts := httptest.NewServer(oauth1Login.WithHTTPClient(proxyClient, handler))
 	http.PostForm(ts.URL, url.Values{accessTokenField: {testTwitterToken}, accessTokenSecretField: {testTwitterTokenSecret}})
 }
 
 func TestTokenHandler_NonPost(t *testing.T) {
 	config := &oauth1.Config{}
-	ts := httptest.NewServer(ctxh.NewHandler(TokenHandler(config, testutils.AssertSuccessNotCalled(t), nil)))
+	ts := httptest.NewServer(TokenHandler(config, testutils.AssertSuccessNotCalled(t), nil))
 	resp, err := http.Get(ts.URL)
 	assert.Nil(t, err)
 	// assert that default (nil) failure handler returns a 405 Method Not Allowed
@@ -98,20 +95,21 @@ func TestTokenHandler_NonPost(t *testing.T) {
 
 func TestTokenHandler_NonPostPassesError(t *testing.T) {
 	config := &oauth1.Config{}
-	failure := func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	failure := func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
 		// assert that Method not allowed error passed through ctx
 		err := gologin.ErrorFromContext(ctx)
 		if assert.Error(t, err) {
 			assert.Equal(t, err, fmt.Errorf("Method not allowed"))
 		}
 	}
-	ts := httptest.NewServer(ctxh.NewHandler(TokenHandler(config, testutils.AssertSuccessNotCalled(t), ctxh.ContextHandlerFunc(failure))))
+	ts := httptest.NewServer(TokenHandler(config, testutils.AssertSuccessNotCalled(t), http.HandlerFunc(failure)))
 	http.Get(ts.URL)
 }
 
 func TestTokenHandler_InvalidFields(t *testing.T) {
 	config := &oauth1.Config{}
-	ts := httptest.NewServer(ctxh.NewHandler(TokenHandler(config, testutils.AssertSuccessNotCalled(t), nil)))
+	ts := httptest.NewServer(TokenHandler(config, testutils.AssertSuccessNotCalled(t), nil))
 
 	// assert errors occur for different missing POST fields
 	resp, err := http.PostForm(ts.URL, nil)


### PR DESCRIPTION
I wanted to build on top this library. But first I wanted to use the new context pkg in GO 1.7. I figured I will send a pr, in case you are interested to merge it.