### PR TITLE
v2.0.0-rc1, Go 1.7+, and standard context support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: go
 go:
-  - 1.6
   - 1.7
   - tip
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
   - 1.7
-  - 1.8beta2
+  - 1.8rc1
   - tip
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 go:
   - 1.7
+  - 1.8beta2
   - tip
 matrix:
   allow_failures:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,6 @@ Notable changes between releases.
 
 ### Migration
 
-* Use Go 1.7+ or use the `gologin` v1.0.0 tag
 * Update `golang.org/x/net/context` imports to `context`
 * Change any `ctxh.ContextHandler` to a `http.Handler`. The `ctx` is passed via the request so the argument is no longer needed.
 * Remove any `ctxh.NewHandler(...)` wrap. `gologin` handlers are now standard `http.Handler`'s, conversion is no longer required.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,22 @@
 
 Notable changes between releases.
 
+## v2.0.0 (TBD)
+
+* Support for Go 1.7+ standard `context`
+* Change `gologin` handlers to be standard `http.Handler`'s
+* Drop requirement for `ctxh.NewHandler` wrapper
+* Drop dependency on `github.com/dghubble/ctxh` shim
+
+### Migration
+
+* Use Go 1.7+ or use the `gologin` v1.0.0 tag
+* Update `golang.org/x/net/context` imports to `context`
+* Change any `ctxh.ContextHandler` to a `http.Handler`. The `ctx` is passed via the request so the argument is no longer needed.
+* Remove any `ctxh.NewHandler(...)` wrap. `gologin` handlers are now standard `http.Handler`'s, conversion is no longer required.
+* Use `req.Context()` to obtain the request context within handlers.
+* See updated [examples](examples)
+
 ## v1.0.1 (2016-10-31)
 
 * Use base64.RawURLEncoding for StateHandler's state (#14)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 
 Notable changes between releases.
 
-## v2.0.0 (TBD)
+## v2.0.0 (2016-01-10)
 
 * Support for Go 1.7+ standard `context`
 * Change `gologin` handlers to be standard `http.Handler`'s

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 # gologin [![Build Status](https://travis-ci.org/dghubble/gologin.svg?branch=master)](https://travis-ci.org/dghubble/gologin) [![GoDoc](https://godoc.org/github.com/dghubble/gologin?status.png)](https://godoc.org/github.com/dghubble/gologin)
 <img align="right" src="https://storage.googleapis.com/dghubble/gologin.png">
 
-Package `gologin` provides chainable login handlers for Google, Github, Twitter, Digits, Facebook, Bitbucket, Tumblr, OAuth1, OAuth2, and other authentication providers.
+Package `gologin` provides chainable login `http.Handler`'s for Google, Github, Twitter, Digits, Facebook, Bitbucket, Tumblr, OAuth1, OAuth2, and other authentication providers.
 
-Choose an auth provider package. Register the `LoginHandler` and `CallbackHandler` for web logins and the `TokenHandler` for (mobile) token logins. Get the verified User/Account and access token from the `ctx`.
+Choose a subpackage. Register the `LoginHandler` and `CallbackHandler` for web logins or the `TokenHandler` for (mobile) token logins. Get the access token or authenticated User/Account from the request `context`.
 
 See [examples](examples) for tutorials with apps you can run from the command line. Visit [whoam.io](https://whoam.io/) to see a live site running on some Kubernetes clusters.
 
-**tldr**: Handlers which implement the steps of standard authentication flows to provide access tokens and associated User/Account structs.
+**Announcement**: Go 1.7+ includes `context` in the standard library. With `gologin` `v2.0.0`, handlers have been updated to standard `http.Handler`'s. See [migration](#migration-from-v100). Those requiring Go 1.6 support should use the v1.0.0 tag.
 
 ### Packages
 
@@ -24,16 +24,12 @@ See [examples](examples) for tutorials with apps you can run from the command li
 
 ## Features
 
+* Authenticate users to obtain an access token or User/Account
 * `LoginHandler` and `CallbackHandler` support web login flows
 * `TokenHandler` supports native mobile token login flows
-* Get the verified User/Account and access token from the `ctx`
-* OAuth 2 State Parameter CSRF protection
-
-## Flexibility
-
-* Handlers work with any mux accepting an `http.Handler`
-* Does not attempt to be your session system or token system.
-* Configurable OAuth 2 state parameter handling
+* Uses standard `http.Handler` and the Go 1.7+ `context`
+* Does not attempt to be your session system or token system
+* Configurable OAuth 2 state parameter handling (CSRF protection)
 * Configurable OAuth 1 request secret handling
 
 ## Install
@@ -44,33 +40,13 @@ See [examples](examples) for tutorials with apps you can run from the command li
 
 Read [GoDoc](https://godoc.org/github.com/dghubble/gologin)
 
-## Goals
+## Overview
 
-Create small, chainable handlers to correctly implement the steps of common authentication flows. Handle provider-specific validation requirements.
-
-## Concept
-
-Package `gologin` provides `ContextHandler`'s which can be chained together to implement authorization flows and pass data (e.g. tokens, users) in a `ctx` argument.
-
-```go
-type ContextHandler interface {
-    ServeHTTP(ctx context.Context, w http.ResponseWriter, req *http.Request)
-}
-```
-
-For example, `oauth2` has handlers which generate a state parameter, redirect users to an AuthURL, or validate a redirectURL callback to exchange for a Token.
-
-`gologin` handlers generally take `success` and `failure` ContextHandlers to be called next if an authentication step succeeds or fails. They populate the `ctx` with values needed for the next step. If the flow succeeds, the last success ContextHandler `ctx` should include the access token and (optional) associated User/Account.
-
-[ctxh](https://github.com/dghubble/ctxh) defines a ContextHandler and some convenience functions to convert to a handler which plays well with `net/http`.
-
-```go
-func NewHandler(h ContextHandler) http.Handler
-```
+Package `gologin` provides `http.Handler`'s which can be chained together to implement authorization flows by passing data (e.g. tokens, users) via the request context. `gologin` handlers take `success` and `failure` next `http.Handler`'s to be called when authentication succeeds or fails. Chaining allows advanced customization, if desired. Once authentication succeeds, your `success` handler will have access to the user's access token and associated User/Account.
 
 ## Usage
 
-Choose an auth provider package such as `github` or `twitter`. These packages chain together lower level `oauth1` and `oauth2` ContextHandlers and fetch the Github or Twitter `User` before calling your success ContextHandler.
+Choose a subpackage such as `github` or `twitter`. `LoginHandler` and `Callback` `http.Handler`'s chain together lower level `oauth1` or `oauth2` handlers to authenticate users and fetch the Github or Twitter `User`, before calling your `success` `http.Handler`.
 
 Let's walk through Github and Twitter web login examples.
 
@@ -87,28 +63,29 @@ config := &oauth2.Config{
 }
 mux := http.NewServeMux()
 stateConfig := gologin.DebugOnlyCookieConfig
-mux.Handle("/login", ctxh.NewHandler(github.StateHandler(stateConfig, github.LoginHandler(config, nil))))
-mux.Handle("/callback", ctxh.NewHandler(github.StateHandler(stateConfig, github.CallbackHandler(config, issueSession(), nil))))
+mux.Handle("/login", github.StateHandler(stateConfig, github.LoginHandler(config, nil)))
+mux.Handle("/callback", github.StateHandler(stateConfig, github.CallbackHandler(config, issueSession(), nil)))
 ```
 
-The `StateHandler` checks for an OAuth2 state parameter cookie, generates a non-guessable state as a short-lived cookie if missing, and passes the state value in the ctx. The `CookieConfig` allows the cookie name or expiration (default 60 seconds) to be configured. In production, use a config like `gologin.DefaultCookieConfig` which sets *Secure* true to require cookies be sent over HTTPS. If you wish to persist state parameters a different way, you may chain your own `ContextHandler`. ([info](#state-parameters))
+The `StateHandler` checks for an OAuth2 state parameter cookie, generates a non-guessable state as a short-lived cookie if missing, and passes the state value in the ctx. The `CookieConfig` allows the cookie name or expiration (default 60 seconds) to be configured. In production, use a config like `gologin.DefaultCookieConfig` which sets *Secure* true to require cookies be sent over HTTPS. If you wish to persist state parameters a different way, you may chain your own `http.Handler`. ([info](#state-parameters))
 
-The `github` `LoginHandler` reads the state from the ctx and redirects to the AuthURL (at github.com) to prompt the user to grant access. Passing nil for the `failure` ContextHandler just means the `DefaultFailureHandler` should be used, which reports errors. ([info](#failure-handlers))
+The `github` `LoginHandler` reads the state from the ctx and redirects to the AuthURL (at github.com) to prompt the user to grant access. Passing nil for the `failure` handler just means the `DefaultFailureHandler` should be used, which reports errors. ([info](#failure-handlers))
 
 The `github` `CallbackHandler` receives an auth code and state OAuth2 redirection, validates the state against the state in the ctx, and exchanges the auth code for an OAuth2 Token. The `github` CallbackHandler wraps the lower level `oauth2` `CallbackHandler` to further use the Token to obtain the Github `User` before calling through to the success or failure handlers.
 
 <img src="https://storage.googleapis.com/dghubble/gologin-github.png">
 
-Next, write the success `ContextHandler` to do something with the Token and Github User added to the `ctx`.
+Next, write the success `http.Handler` to do something with the Token and Github User added to the `ctx`.
 
 ```go
-func issueSession() ctxh.ContextHandler {
-    fn := func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+func issueSession() http.Handler {
+    fn := func(w http.ResponseWriter, req *http.Request) {
+        ctx := req.Context()
         token, _ := oauth2Login.TokenFromContext(ctx)
         githubUser, err := github.UserFromContext(ctx)
         // handle errors and grant the visitor a session (cookie, token, etc.)
     }
-    return ctxh.ContextHandlerFunc(fn)
+    return http.HandlerFunc(fn)
 }
 ```
 
@@ -126,26 +103,27 @@ config := &oauth1.Config{
     Endpoint:       twitterOAuth1.AuthorizeEndpoint,
 }
 mux := http.NewServeMux()
-mux.Handle("/login", ctxh.NewHandler(twitter.LoginHandler(config, nil)))
-mux.Handle("/callback", ctxh.NewHandler(twitter.CallbackHandler(config, issueSession(), nil)))
+mux.Handle("/login", twitter.LoginHandler(config, nil))
+mux.Handle("/callback", twitter.CallbackHandler(config, issueSession(), nil))
 ```
 
-The `twitter` `LoginHandler` obtains a request token and secret, adds them to the ctx, and redirects to the AuthorizeURL to prompt the user to grant access. Passing nil for the `failure` ContextHandler just means the `DefaultFailureHandler` should be used, which reports errors. ([info](#failure-handlers))
+The `twitter` `LoginHandler` obtains a request token and secret, adds them to the ctx, and redirects to the AuthorizeURL to prompt the user to grant access. Passing nil for the `failure` handler just means the `DefaultFailureHandler` should be used, which reports errors. ([info](#failure-handlers))
 
 The `twitter` `CallbackHandler` receives an OAuth1 token and verifier, reads the request secret from the ctx, and obtains an OAuth1 access token and secret. The `twitter` CallbackHandler wraps the lower level `oauth1` CallbackHandler to further use the access token/secret to obtain the Twitter `User` before calling through to the success or failure handlers.
 
 <img src="https://storage.googleapis.com/dghubble/gologin-twitter.png">
 
-Next, write the success `ContextHandler` to do something with the access token/secret and Twitter User added to the `ctx`.
+Next, write the success `http.Handler` to do something with the access token/secret and Twitter User added to the `ctx`.
 
 ```go
-func success() ctxh.ContextHandler {
-    fn := func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+func success() http.Handler {
+    fn := func(w http.ResponseWriter, req *http.Request) {
+        ctx := req.Context()
         accessToken, accessSecret, _ := oauth1Login.AccessTokenFromContext(ctx)
         twitterUser, err := twitter.UserFromContext(ctx)
         // handle errors and grant the visitor a session (cookie, token, etc.)
     }
-    return ctxh.ContextHandlerFunc(fn)
+    return http.HandlerFunc(fn)
 }
 ```
 
@@ -155,13 +133,13 @@ See the [Twitter tutorial](examples/twitter) for a web app you can run from the 
 
 ### State Parameters
 
-OAuth2 `StateHandler` implements OAuth 2 [RFC 6749](https://tools.ietf.org/html/rfc6749) 10.12 CSRF Protection using non-guessable values in short-lived HTTPS-only cookies to provide reasonable assurance the user in the login phase and callback phase are the same. If you wish to implement this differently, write a `ContextHandler` which sets a *state* in the ctx, which is expected by LoginHandler and CallbackHandler.
+OAuth2 `StateHandler` implements OAuth 2 [RFC 6749](https://tools.ietf.org/html/rfc6749) 10.12 CSRF Protection using non-guessable values in short-lived HTTPS-only cookies to provide reasonable assurance the user in the login phase and callback phase are the same. If you wish to implement this differently, write a `http.Handler` which sets a *state* in the ctx, which is expected by LoginHandler and CallbackHandler.
 
 You may use `oauth2.WithState(context.Context, state string)` for this. [docs](https://godoc.org/github.com/dghubble/gologin/oauth2#WithState)
 
 ### Failure Handlers
 
-If you wish to define your own failure `ContextHandler`, you can get the error from the `ctx` using `gologin.ErrorFromContext(ctx)`.
+If you wish to define your own failure `http.Handler`, you can get the error from the `ctx` using `gologin.ErrorFromContext(ctx)`.
 
 ### Production Requirements
 
@@ -169,13 +147,20 @@ If you wish to define your own failure `ContextHandler`, you can get the error f
 * Never put consumer/client secrets in source control.
 * Ensure the CookieConfig requires state or temp credential cookies be sent over HTTPS-only.
 
-### Going Further
+### Migration from v1.0.0
 
-Check out the available auth provider packages. Each has handlers for the web authorization flow and ensures the `ctx` contains the appropriate type of user/account and the access token.
+* Update `golang.org/x/net/context` imports to `context`, which is part of the standard library in Go 1.7+
+* Change any `ctxh.ContextHandler` to a `http.Handler`. The `ctx` is passed via the request so the argument is no longer needed.
+* Remove any `ctxh.NewHandler(...)` wrap. `gologin` handlers are now standard `http.Handler`'s, conversion is no longer required.
+* Use `req.Context()` to obtain the request context within handlers.
 
 ## Mobile
 
 Twitter and Digits include a `TokenHandler` which can be useful for building APIs for mobile devices which use Login with Twitter or Login with Digits.
+
+## Goals
+
+Create small, chainable handlers to correctly implement the steps of common authentication flows. Handle provider-specific validation requirements.
 
 ## Motivations
 
@@ -185,40 +170,14 @@ Package `gologin` implements authorization flow steps with chained handlers.
 * Authentication should be orthogonal to the session system. Let users choose their session/token library.
 * OAuth2 State CSRF should be included out of the box, but easy to customize.
 * Packages should import only what is required. OAuth1 and OAuth2 packages are separate.
-* ContextHandlers are flexible and useful for more than just data passing.
+* `http.Handler` and `context` are powerful, flexible, and in the standard library.
 
 Projects [goth](https://github.com/markbates/goth) and [gomniauth](https://github.com/stretchr/gomniauth) aim to provide a similar login solution with a different design. Check them out if you decide you don't like the ideas in `gologin`.
 
-## Roadmap
-
-* Improve test coverage
-* OTP Handlers
-* Per-Provider User types (current) vs one combined gologin User type?
-
 ## Contributing
 
-Contributions are welcome. Improving documentation and examples is a good way to start. New auth providers can be implemented by composing the `oauth1` or `oauth2` ContextHandlers.
-
-Also, `gologin` aims to use the defacto standard API libraries for User/Account models and verify endpoints. Tumblr and Bitbucket don't seem to have good ones yet. Tiny internal API clients are used.
-
-See the [Contributing Guide](https://gist.github.com/dghubble/be682c123727f70bcfe7).
-
-### Why Contexts?
-
-I originally thought `gologin` should use only `http.Handler` handlers and `handler(http.Handler) http.Handler` chaining. Passing request data becomes messy with many custom handler types. Global request to context mappings are similarly gross.
-
-A while ago, some great materials like this Go [blog post](https://blog.golang.org/context), Sameer Ajmani's [Gotham talk](https://vimeo.com/115309491), and Joe Shaw's [article](https://joeshaw.org/net-context-and-http-handler/) helped convince me that 
-
-```go
-type ContextHandler interface {
-    ServeHTTP(ctx context.Context, w http.ResponseWriter, req *http.Request)
-}
-```
-
-is an excellent choice for more advanced handlers. These days I use it a lot.
+New auth providers can be implemented by composing the handlers in the `oauth1` or `oauth2` subpackages. See the [Contributing Guide](https://gist.github.com/dghubble/be682c123727f70bcfe7).
 
 ## License
 
 [MIT License](LICENSE)
-
-

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Choose a subpackage. Register the `LoginHandler` and `CallbackHandler` for web l
 
 See [examples](examples) for tutorials with apps you can run from the command line. Visit [whoam.io](https://whoam.io/) to see a live site running on some Kubernetes clusters.
 
-**Announcement**: Go 1.7+ includes `context` in the standard library. With `gologin` `v2.0.0`, handlers have been updated to standard `http.Handler`'s. See [migration](#migration-from-v100). Those requiring Go 1.6 support should use the v1.0.0 tag.
+**Announcement**: Go 1.7+ includes `context` in the standard library. With `gologin` `v2.0.0`, handlers have been updated to standard `http.Handler`'s. See [migration](#migration-from-v100). Those requiring Go 1.6 support should use the latest `v1.0.*` tag.
 
 ### Packages
 

--- a/bitbucket/context.go
+++ b/bitbucket/context.go
@@ -1,9 +1,8 @@
 package bitbucket
 
 import (
+	"context"
 	"fmt"
-
-	"golang.org/x/net/context"
 )
 
 // unexported key type prevents collisions

--- a/bitbucket/context_test.go
+++ b/bitbucket/context_test.go
@@ -1,10 +1,10 @@
 package bitbucket
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 )
 
 func TestContextUser(t *testing.T) {

--- a/bitbucket/login.go
+++ b/bitbucket/login.go
@@ -19,7 +19,7 @@ var (
 // and to a (short-lived) state cookie issued to the requester.
 //
 // Implements OAuth 2 RFC 6749 10.12 CSRF Protection. If you wish to issue
-// state params differently, write a ContextHandler which sets the ctx state,
+// state params differently, write a http.Handler which sets the ctx state,
 // using oauth2 WithState(ctx, state) since it is required by LoginHandler
 // and CallbackHandler.
 func StateHandler(config gologin.CookieConfig, success http.Handler) http.Handler {
@@ -41,7 +41,7 @@ func CallbackHandler(config *oauth2.Config, success, failure http.Handler) http.
 	return oauth2Login.CallbackHandler(config, success, failure)
 }
 
-// bitbucketHandler is a ContextHandler that gets the OAuth2 Token from the ctx
+// bitbucketHandler is a http.Handler that gets the OAuth2 Token from the ctx
 // to get the corresponding Bitbucket User. If successful, the User is added to
 // the ctx and the success handler is called. Otherwise, the failure handler is
 // called.

--- a/bitbucket/login.go
+++ b/bitbucket/login.go
@@ -4,10 +4,8 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/dghubble/ctxh"
 	"github.com/dghubble/gologin"
 	oauth2Login "github.com/dghubble/gologin/oauth2"
-	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 )
 
@@ -24,13 +22,13 @@ var (
 // state params differently, write a ContextHandler which sets the ctx state,
 // using oauth2 WithState(ctx, state) since it is required by LoginHandler
 // and CallbackHandler.
-func StateHandler(config gologin.CookieConfig, success ctxh.ContextHandler) ctxh.ContextHandler {
+func StateHandler(config gologin.CookieConfig, success http.Handler) http.Handler {
 	return oauth2Login.StateHandler(config, success)
 }
 
 // LoginHandler handles Bitbucket login requests by reading the state value
 // from the ctx and redirecting requests to the AuthURL with that state value.
-func LoginHandler(config *oauth2.Config, failure ctxh.ContextHandler) ctxh.ContextHandler {
+func LoginHandler(config *oauth2.Config, failure http.Handler) http.Handler {
 	return oauth2Login.LoginHandler(config, failure)
 }
 
@@ -38,7 +36,7 @@ func LoginHandler(config *oauth2.Config, failure ctxh.ContextHandler) ctxh.Conte
 // Bitbucket access token and User to the ctx. If authentication succeeds,
 // handling delegates to the success handler, otherwise to the failure
 // handler.
-func CallbackHandler(config *oauth2.Config, success, failure ctxh.ContextHandler) ctxh.ContextHandler {
+func CallbackHandler(config *oauth2.Config, success, failure http.Handler) http.Handler {
 	success = bitbucketHandler(config, success, failure)
 	return oauth2Login.CallbackHandler(config, success, failure)
 }
@@ -47,15 +45,16 @@ func CallbackHandler(config *oauth2.Config, success, failure ctxh.ContextHandler
 // to get the corresponding Bitbucket User. If successful, the User is added to
 // the ctx and the success handler is called. Otherwise, the failure handler is
 // called.
-func bitbucketHandler(config *oauth2.Config, success, failure ctxh.ContextHandler) ctxh.ContextHandler {
+func bitbucketHandler(config *oauth2.Config, success, failure http.Handler) http.Handler {
 	if failure == nil {
 		failure = gologin.DefaultFailureHandler
 	}
-	fn := func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	fn := func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
 		token, err := oauth2Login.TokenFromContext(ctx)
 		if err != nil {
 			ctx = gologin.WithError(ctx, err)
-			failure.ServeHTTP(ctx, w, req)
+			failure.ServeHTTP(w, req.WithContext(ctx))
 			return
 		}
 		httpClient := config.Client(ctx, token)
@@ -64,13 +63,13 @@ func bitbucketHandler(config *oauth2.Config, success, failure ctxh.ContextHandle
 		err = validateResponse(user, resp, err)
 		if err != nil {
 			ctx = gologin.WithError(ctx, err)
-			failure.ServeHTTP(ctx, w, req)
+			failure.ServeHTTP(w, req.WithContext(ctx))
 			return
 		}
 		ctx = WithUser(ctx, user)
-		success.ServeHTTP(ctx, w, req)
+		success.ServeHTTP(w, req.WithContext(ctx))
 	}
-	return ctxh.ContextHandlerFunc(fn)
+	return http.HandlerFunc(fn)
 }
 
 // validateResponse returns an error if the given Bitbucket User, raw

--- a/bitbucket/login_test.go
+++ b/bitbucket/login_test.go
@@ -1,17 +1,16 @@
 package bitbucket
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
-	"github.com/dghubble/ctxh"
 	"github.com/dghubble/gologin"
 	oauth2Login "github.com/dghubble/gologin/oauth2"
 	"github.com/dghubble/gologin/testutils"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 )
 
@@ -26,7 +25,8 @@ func TestBitbucketHandler(t *testing.T) {
 	ctx = oauth2Login.WithToken(ctx, anyToken)
 
 	config := &oauth2.Config{}
-	success := func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	success := func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
 		bitbucketUser, err := UserFromContext(ctx)
 		assert.Nil(t, err)
 		assert.Equal(t, expectedUser, bitbucketUser)
@@ -39,17 +39,18 @@ func TestBitbucketHandler(t *testing.T) {
 	// - bitbucket User is obtained from the Bitbucket API
 	// - success handler is called
 	// - bitbucket User is added to the ctx of the success handler
-	bitbucketHandler := bitbucketHandler(config, ctxh.ContextHandlerFunc(success), failure)
+	bitbucketHandler := bitbucketHandler(config, http.HandlerFunc(success), failure)
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/", nil)
-	bitbucketHandler.ServeHTTP(ctx, w, req)
+	bitbucketHandler.ServeHTTP(w, req.WithContext(ctx))
 	assert.Equal(t, "success handler called", w.Body.String())
 }
 
 func TestBitbucketHandler_MissingCtxToken(t *testing.T) {
 	config := &oauth2.Config{}
 	success := testutils.AssertSuccessNotCalled(t)
-	failure := func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	failure := func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
 		err := gologin.ErrorFromContext(ctx)
 		if assert.NotNil(t, err) {
 			assert.Equal(t, "oauth2: Context missing Token", err.Error())
@@ -60,10 +61,10 @@ func TestBitbucketHandler_MissingCtxToken(t *testing.T) {
 	// BitbucketHandler called without Token in ctx, assert that:
 	// - failure handler is called
 	// - error about ctx missing token is added to the failure handler ctx
-	bitbucketHandler := bitbucketHandler(config, success, ctxh.ContextHandlerFunc(failure))
+	bitbucketHandler := bitbucketHandler(config, success, http.HandlerFunc(failure))
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/", nil)
-	bitbucketHandler.ServeHTTP(context.Background(), w, req)
+	bitbucketHandler.ServeHTTP(w, req)
 	assert.Equal(t, "failure handler called", w.Body.String())
 }
 
@@ -77,7 +78,8 @@ func TestBitbucketHandler_ErrorGettingUser(t *testing.T) {
 
 	config := &oauth2.Config{}
 	success := testutils.AssertSuccessNotCalled(t)
-	failure := func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	failure := func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
 		err := gologin.ErrorFromContext(ctx)
 		if assert.NotNil(t, err) {
 			assert.Equal(t, ErrUnableToGetBitbucketUser, err)
@@ -88,10 +90,10 @@ func TestBitbucketHandler_ErrorGettingUser(t *testing.T) {
 	// BitbucketHandler cannot get Bitbucket User, assert that:
 	// - failure handler is called
 	// - error cannot get Bitbucket User added to the failure handler ctx
-	bitbucketHandler := bitbucketHandler(config, success, ctxh.ContextHandlerFunc(failure))
+	bitbucketHandler := bitbucketHandler(config, success, http.HandlerFunc(failure))
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/", nil)
-	bitbucketHandler.ServeHTTP(ctx, w, req)
+	bitbucketHandler.ServeHTTP(w, req.WithContext(ctx))
 	assert.Equal(t, "failure handler called", w.Body.String())
 }
 

--- a/context.go
+++ b/context.go
@@ -1,9 +1,8 @@
 package gologin
 
 import (
+	"context"
 	"fmt"
-
-	"golang.org/x/net/context"
 )
 
 // unexported key type prevents collisions

--- a/context_test.go
+++ b/context_test.go
@@ -1,11 +1,11 @@
 package gologin
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 )
 
 func TestContextError(t *testing.T) {

--- a/digits/context.go
+++ b/digits/context.go
@@ -1,10 +1,10 @@
 package digits
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/dghubble/go-digits/digits"
-	"golang.org/x/net/context"
 )
 
 // unexported key type prevents collisions

--- a/digits/login.go
+++ b/digits/login.go
@@ -6,11 +6,9 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/dghubble/ctxh"
 	"github.com/dghubble/go-digits/digits"
 	"github.com/dghubble/gologin"
 	"github.com/dghubble/sling"
-	"golang.org/x/net/context"
 )
 
 const (
@@ -41,15 +39,16 @@ type Config struct {
 // validates the echo, and calls the endpoint to get the corresponding Digits
 // Account. If successful, the Digits Account is added to the ctx and the
 // success handler is called. Otherwise, the failure handler is called.
-func LoginHandler(config *Config, success, failure ctxh.ContextHandler) ctxh.ContextHandler {
+func LoginHandler(config *Config, success, failure http.Handler) http.Handler {
 	success = getAccountViaEcho(config, success, failure)
 	if failure == nil {
 		failure = gologin.DefaultFailureHandler
 	}
-	fn := func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	fn := func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
 		if req.Method != "POST" {
 			ctx = gologin.WithError(ctx, fmt.Errorf("Method not allowed"))
-			failure.ServeHTTP(ctx, w, req)
+			failure.ServeHTTP(w, req.WithContext(ctx))
 			return
 		}
 		req.ParseForm()
@@ -59,20 +58,20 @@ func LoginHandler(config *Config, success, failure ctxh.ContextHandler) ctxh.Con
 		err := validateEcho(accountEndpoint, accountRequestHeader, config.ConsumerKey)
 		if err != nil {
 			ctx = gologin.WithError(ctx, err)
-			failure.ServeHTTP(ctx, w, req)
+			failure.ServeHTTP(w, req.WithContext(ctx))
 			return
 		}
 		ctx = WithEcho(ctx, accountEndpoint, accountRequestHeader)
-		success.ServeHTTP(ctx, w, req)
+		success.ServeHTTP(w, req.WithContext(ctx))
 	}
-	return ctxh.ContextHandlerFunc(fn)
+	return http.HandlerFunc(fn)
 }
 
 // getAccountViaEcho is a ContextHandler that gets the Digits Echo endpoint and
 // OAuth header from the ctx and calls the endpoint to get the corresponding
 // Digits Account. If successful, the Account is added to the ctx and the
 // success handler is called. Otherwise, the failure handler is called.
-func getAccountViaEcho(config *Config, success, failure ctxh.ContextHandler) ctxh.ContextHandler {
+func getAccountViaEcho(config *Config, success, failure http.Handler) http.Handler {
 	if failure == nil {
 		failure = gologin.DefaultFailureHandler
 	}
@@ -80,11 +79,12 @@ func getAccountViaEcho(config *Config, success, failure ctxh.ContextHandler) ctx
 	if client == nil {
 		client = http.DefaultClient
 	}
-	fn := func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	fn := func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
 		endpoint, header, err := EchoFromContext(ctx)
 		if err != nil {
 			ctx = gologin.WithError(ctx, err)
-			failure.ServeHTTP(ctx, w, req)
+			failure.ServeHTTP(w, req.WithContext(ctx))
 			return
 		}
 		// fetch the Digits Account
@@ -93,13 +93,13 @@ func getAccountViaEcho(config *Config, success, failure ctxh.ContextHandler) ctx
 		err = validateResponse(account, resp, err)
 		if err != nil {
 			ctx = gologin.WithError(ctx, err)
-			failure.ServeHTTP(ctx, w, req)
+			failure.ServeHTTP(w, req.WithContext(ctx))
 			return
 		}
 		ctx = WithAccount(ctx, account)
-		success.ServeHTTP(ctx, w, req)
+		success.ServeHTTP(w, req.WithContext(ctx))
 	}
-	return ctxh.ContextHandlerFunc(fn)
+	return http.HandlerFunc(fn)
 }
 
 // validateEcho checks that the Digits OAuth Echo arguments are valid. If the

--- a/digits/login.go
+++ b/digits/login.go
@@ -67,7 +67,7 @@ func LoginHandler(config *Config, success, failure http.Handler) http.Handler {
 	return http.HandlerFunc(fn)
 }
 
-// getAccountViaEcho is a ContextHandler that gets the Digits Echo endpoint and
+// getAccountViaEcho is a http.Handler that gets the Digits Echo endpoint and
 // OAuth header from the ctx and calls the endpoint to get the corresponding
 // Digits Account. If successful, the Account is added to the ctx and the
 // success handler is called. Otherwise, the failure handler is called.

--- a/digits/token.go
+++ b/digits/token.go
@@ -4,12 +4,10 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/dghubble/ctxh"
 	"github.com/dghubble/go-digits/digits"
 	"github.com/dghubble/gologin"
 	oauth1Login "github.com/dghubble/gologin/oauth1"
 	"github.com/dghubble/oauth1"
-	"golang.org/x/net/context"
 )
 
 const (
@@ -27,15 +25,16 @@ var (
 // accounts endpoint to get the corresponding Account. If successful, the
 // access token/secret and Account are added to the ctx and the success handler
 // is called. Otherwise, the failure handler is called.
-func TokenHandler(config *oauth1.Config, success, failure ctxh.ContextHandler) ctxh.ContextHandler {
+func TokenHandler(config *oauth1.Config, success, failure http.Handler) http.Handler {
 	success = digitsHandler(config, success, failure)
 	if failure == nil {
 		failure = gologin.DefaultFailureHandler
 	}
-	fn := func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	fn := func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
 		if req.Method != "POST" {
 			ctx = gologin.WithError(ctx, fmt.Errorf("Method not allowed"))
-			failure.ServeHTTP(ctx, w, req)
+			failure.ServeHTTP(w, req.WithContext(ctx))
 			return
 		}
 		req.ParseForm()
@@ -44,28 +43,29 @@ func TokenHandler(config *oauth1.Config, success, failure ctxh.ContextHandler) c
 		err := validateToken(accessToken, accessSecret)
 		if err != nil {
 			ctx = gologin.WithError(ctx, err)
-			failure.ServeHTTP(ctx, w, req)
+			failure.ServeHTTP(w, req.WithContext(ctx))
 			return
 		}
 		ctx = oauth1Login.WithAccessToken(ctx, accessToken, accessSecret)
-		success.ServeHTTP(ctx, w, req)
+		success.ServeHTTP(w, req.WithContext(ctx))
 	}
-	return ctxh.ContextHandlerFunc(fn)
+	return http.HandlerFunc(fn)
 }
 
 // digitsHandler is a ContextHandler that gets the OAuth1 access token from the
 // ctx and calls the Digits accounts endpoint to get the corresponding Account.
 // If successful, the Account is added to the ctx and the success handler is
 // called. Otherwise, the failure handler is called.
-func digitsHandler(config *oauth1.Config, success, failure ctxh.ContextHandler) ctxh.ContextHandler {
+func digitsHandler(config *oauth1.Config, success, failure http.Handler) http.Handler {
 	if failure == nil {
 		failure = gologin.DefaultFailureHandler
 	}
-	fn := func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	fn := func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
 		accessToken, accessSecret, err := oauth1Login.AccessTokenFromContext(ctx)
 		if err != nil {
 			ctx = gologin.WithError(ctx, err)
-			failure.ServeHTTP(ctx, w, req)
+			failure.ServeHTTP(w, req.WithContext(ctx))
 			return
 		}
 		httpClient := config.Client(ctx, oauth1.NewToken(accessToken, accessSecret))
@@ -74,13 +74,13 @@ func digitsHandler(config *oauth1.Config, success, failure ctxh.ContextHandler) 
 		err = validateResponse(account, resp, err)
 		if err != nil {
 			ctx = gologin.WithError(ctx, err)
-			failure.ServeHTTP(ctx, w, req)
+			failure.ServeHTTP(w, req.WithContext(ctx))
 			return
 		}
 		ctx = WithAccount(ctx, account)
-		success.ServeHTTP(ctx, w, req)
+		success.ServeHTTP(w, req.WithContext(ctx))
 	}
-	return ctxh.ContextHandlerFunc(fn)
+	return http.HandlerFunc(fn)
 }
 
 // validateToken returns an error if the token or token secret is missing.

--- a/digits/token.go
+++ b/digits/token.go
@@ -52,7 +52,7 @@ func TokenHandler(config *oauth1.Config, success, failure http.Handler) http.Han
 	return http.HandlerFunc(fn)
 }
 
-// digitsHandler is a ContextHandler that gets the OAuth1 access token from the
+// digitsHandler is a http.Handler that gets the OAuth1 access token from the
 // ctx and calls the Digits accounts endpoint to get the corresponding Account.
 // If successful, the Account is added to the ctx and the success handler is
 // called. Otherwise, the failure handler is called.

--- a/digits/token_test.go
+++ b/digits/token_test.go
@@ -1,11 +1,15 @@
 package digits
 
 import (
+	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 
+	"github.com/dghubble/gologin"
 	oauth1Login "github.com/dghubble/gologin/oauth1"
 	"github.com/dghubble/gologin/testutils"
 	"github.com/dghubble/oauth1"
@@ -30,6 +34,9 @@ func TestTokenHandler(t *testing.T) {
 	proxyClient, _, server := newDigitsTestServer(testAccountJSON)
 	defer server.Close()
 
+	// oauth1 Client will use the proxy client's base Transport
+	ctx := context.WithValue(context.Background(), oauth1.HTTPClient, proxyClient)
+
 	config := &oauth1.Config{}
 	success := func(w http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
@@ -43,29 +50,51 @@ func TestTokenHandler(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, testDigitsToken, accessToken)
 		assert.Equal(t, testDigitsSecret, accessSecret)
+		fmt.Fprintf(w, "success handler called")
 	}
-	handler := TokenHandler(config, http.HandlerFunc(success), testutils.AssertFailureNotCalled(t))
-	// oauth1 Client will use the proxy client's base Transport
-	ts := httptest.NewServer(oauth1Login.WithHTTPClient(proxyClient, handler))
-	// POST Digits access token to server under test
-	resp, err := http.PostForm(ts.URL, url.Values{accessTokenField: {testDigitsToken}, accessTokenSecretField: {testDigitsSecret}})
-	assert.Nil(t, err)
-	if assert.NotNil(t, resp) {
-		assert.Equal(t, resp.StatusCode, http.StatusOK)
-	}
+
+	// TokenHandler assert that:
+	// - access token/secret are read from POST
+	// - digits account is obtained from the Digits accounts endpoint
+	// - success handler is called
+	// - digits account is added to the success handler ctx
+	tokenHandler := TokenHandler(config, http.HandlerFunc(success), testutils.AssertFailureNotCalled(t))
+	w := httptest.NewRecorder()
+	form := url.Values{accessTokenField: {testDigitsToken}, accessTokenSecretField: {testDigitsSecret}}
+	req, _ := http.NewRequest("POST", "/", strings.NewReader(form.Encode()))
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	tokenHandler.ServeHTTP(w, req.WithContext(ctx))
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "success handler called", w.Body.String())
 }
 
 func TestTokenHandler_ErrorVerifyingToken(t *testing.T) {
 	proxyClient, server := testutils.NewErrorServer("Digits Account Endpoint Down", http.StatusInternalServerError)
 	defer server.Close()
 
-	config := &oauth1.Config{}
-	handler := TokenHandler(config, testutils.AssertSuccessNotCalled(t), nil)
 	// oauth1 Client will use the proxy client's base Transport
-	ts := httptest.NewServer(oauth1Login.WithHTTPClient(proxyClient, handler))
-	// assert that error occurs indicating the Digits Account could not be confirmed
-	resp, _ := http.PostForm(ts.URL, url.Values{accessTokenField: {testDigitsToken}, accessTokenSecretField: {testDigitsSecret}})
-	testutils.AssertBodyString(t, resp.Body, ErrUnableToGetDigitsAccount.Error()+"\n")
+	ctx := context.WithValue(context.Background(), oauth1.HTTPClient, proxyClient)
+
+	config := &oauth1.Config{}
+	failure := func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
+		err := gologin.ErrorFromContext(ctx)
+		if assert.Error(t, err) {
+			assert.Equal(t, err, ErrUnableToGetDigitsAccount)
+		}
+		fmt.Fprintf(w, "failure handler called")
+	}
+
+	// TokenHandler cannot verify Digits account, assert that:
+	// - failure handler is called
+	// - error is added to the failure handler context
+	tokenHandler := TokenHandler(config, testutils.AssertSuccessNotCalled(t), http.HandlerFunc(failure))
+	w := httptest.NewRecorder()
+	form := url.Values{accessTokenField: {testDigitsToken}, accessTokenSecretField: {testDigitsSecret}}
+	req, _ := http.NewRequest("POST", "/", strings.NewReader(form.Encode()))
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	tokenHandler.ServeHTTP(w, req.WithContext(ctx))
+	assert.Equal(t, "failure handler called", w.Body.String())
 }
 
 func TestTokenHandler_NonPost(t *testing.T) {

--- a/digits/token_test.go
+++ b/digits/token_test.go
@@ -6,12 +6,10 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/dghubble/ctxh"
 	oauth1Login "github.com/dghubble/gologin/oauth1"
 	"github.com/dghubble/gologin/testutils"
 	"github.com/dghubble/oauth1"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 )
 
 func TestValidateToken_missingToken(t *testing.T) {
@@ -31,11 +29,10 @@ func TestValidateToken_missingTokenSecret(t *testing.T) {
 func TestTokenHandler(t *testing.T) {
 	proxyClient, _, server := newDigitsTestServer(testAccountJSON)
 	defer server.Close()
-	// oauth1 Client will use the proxy client's base Transport
-	ctx := context.WithValue(context.Background(), oauth1.HTTPClient, proxyClient)
 
 	config := &oauth1.Config{}
-	success := func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	success := func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
 		account, err := AccountFromContext(ctx)
 		assert.Nil(t, err)
 		assert.Equal(t, testDigitsToken, account.AccessToken.Token)
@@ -47,8 +44,9 @@ func TestTokenHandler(t *testing.T) {
 		assert.Equal(t, testDigitsToken, accessToken)
 		assert.Equal(t, testDigitsSecret, accessSecret)
 	}
-	handler := TokenHandler(config, ctxh.ContextHandlerFunc(success), testutils.AssertFailureNotCalled(t))
-	ts := httptest.NewServer(ctxh.NewHandlerWithContext(ctx, handler))
+	handler := TokenHandler(config, http.HandlerFunc(success), testutils.AssertFailureNotCalled(t))
+	// oauth1 Client will use the proxy client's base Transport
+	ts := httptest.NewServer(oauth1Login.WithHTTPClient(proxyClient, handler))
 	// POST Digits access token to server under test
 	resp, err := http.PostForm(ts.URL, url.Values{accessTokenField: {testDigitsToken}, accessTokenSecretField: {testDigitsSecret}})
 	assert.Nil(t, err)
@@ -60,12 +58,11 @@ func TestTokenHandler(t *testing.T) {
 func TestTokenHandler_ErrorVerifyingToken(t *testing.T) {
 	proxyClient, server := testutils.NewErrorServer("Digits Account Endpoint Down", http.StatusInternalServerError)
 	defer server.Close()
-	// oauth1 Client will use the proxy client's base Transport
-	ctx := context.WithValue(context.Background(), oauth1.HTTPClient, proxyClient)
 
 	config := &oauth1.Config{}
 	handler := TokenHandler(config, testutils.AssertSuccessNotCalled(t), nil)
-	ts := httptest.NewServer(ctxh.NewHandlerWithContext(ctx, handler))
+	// oauth1 Client will use the proxy client's base Transport
+	ts := httptest.NewServer(oauth1Login.WithHTTPClient(proxyClient, handler))
 	// assert that error occurs indicating the Digits Account could not be confirmed
 	resp, _ := http.PostForm(ts.URL, url.Values{accessTokenField: {testDigitsToken}, accessTokenSecretField: {testDigitsSecret}})
 	testutils.AssertBodyString(t, resp.Body, ErrUnableToGetDigitsAccount.Error()+"\n")
@@ -74,7 +71,7 @@ func TestTokenHandler_ErrorVerifyingToken(t *testing.T) {
 func TestTokenHandler_NonPost(t *testing.T) {
 	config := &oauth1.Config{}
 	handler := TokenHandler(config, testutils.AssertSuccessNotCalled(t), nil)
-	ts := httptest.NewServer(ctxh.NewHandler(handler))
+	ts := httptest.NewServer(handler)
 	resp, err := http.Get(ts.URL)
 	assert.Nil(t, err)
 	// assert that default (nil) failure handler returns a 405 Method Not Allowed
@@ -87,7 +84,7 @@ func TestTokenHandler_NonPost(t *testing.T) {
 func TestTokenHandler_InvalidFields(t *testing.T) {
 	config := &oauth1.Config{}
 	handler := TokenHandler(config, testutils.AssertSuccessNotCalled(t), nil)
-	ts := httptest.NewServer(ctxh.NewHandler(handler))
+	ts := httptest.NewServer(handler)
 
 	// asert errors occur for different missing POST fields
 	resp, err := http.PostForm(ts.URL, url.Values{"wrongFieldName": {testDigitsToken}, accessTokenSecretField: {testDigitsSecret}})

--- a/errors.go
+++ b/errors.go
@@ -2,16 +2,14 @@ package gologin
 
 import (
 	"net/http"
-
-	"github.com/dghubble/ctxh"
-	"golang.org/x/net/context"
 )
 
 // DefaultFailureHandler responds with a 400 status code and message parsed
 // from the ctx.
-var DefaultFailureHandler = ctxh.ContextHandlerFunc(failureHandler)
+var DefaultFailureHandler = http.HandlerFunc(failureHandler)
 
-func failureHandler(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+func failureHandler(w http.ResponseWriter, req *http.Request) {
+	ctx := req.Context()
 	err := ErrorFromContext(ctx)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,13 +1,13 @@
 package gologin
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 )
 
 func TestDefaultFailureHandler(t *testing.T) {
@@ -16,7 +16,7 @@ func TestDefaultFailureHandler(t *testing.T) {
 	req, err := http.NewRequest("GET", "/", nil)
 	assert.Nil(t, err)
 	w := httptest.NewRecorder()
-	DefaultFailureHandler.ServeHTTP(ctx, w, req)
+	DefaultFailureHandler.ServeHTTP(w, req.WithContext(ctx))
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	// assert that error message was passed through
 	assert.Equal(t, expectedError.Error()+"\n", w.Body.String())

--- a/examples/digits/README.md
+++ b/examples/digits/README.md
@@ -42,7 +42,7 @@ Here is what the web login flow looks like (showing a mobile browser).
 
 2. User enters a phone number and receives an SMS confirmation number to enter. The page receives OAuth Echo fields and POSTs them to the Go server.
 
-3. The Echo fields are validated, used to obtain the Digits `Account`, and provided to the specified success `ContextHandler`.
+3. The Echo fields are validated, used to obtain the Digits `Account`, and provided to the specified success `http.Handler`.
 
 4. In this example, that account is read and used to issue the user a signed cookie session.
 

--- a/examples/facebook/README.md
+++ b/examples/facebook/README.md
@@ -36,6 +36,6 @@ Here's what the flow looks like.
 
 1. The "Login with Facebook" link to the login handler directs the user to the Facebook OAuth2 Auth URL to obtain a permission grant.
 2. The redirection URI (callback handler) receives the OAuth2 callback, verifies the state parameter, and obtains a Token.
-3. The success `ContextHandler` is called with a `Context` which contains the Facebook Token and verified Facebook User struct.
+3. The success `http.Handler` is called with a `Context` which contains the Facebook Token and verified Facebook User struct.
 4. In this example, that User is read and used to issue a signed cookie session.
 

--- a/examples/github/README.md
+++ b/examples/github/README.md
@@ -34,6 +34,6 @@ Here's what the flow looks like.
 
 1. Clicking the "Login with Github" link to the login handler directs the user to the Github OAuth2 Auth URL to obtain a permission grant.
 2. The redirection URI (callback handler) receives the OAuth2 callback, verifies the state parameter, and obtains a Token.
-3. The success `ContextHandler` is called with a `Context` which contains the Github Token and verified Github User struct.
+3. The success `http.Handler` is called with a `Context` which contains the Github Token and verified Github User struct.
 4. In this example, that User is read and used to issue a signed cookie session.
 

--- a/examples/google/README.md
+++ b/examples/google/README.md
@@ -17,7 +17,7 @@ Package `gologin` provides Go handlers for the Google OAuth2 Authorization flow 
 
 [main.go](main.go) shows an example web app which uses `gologin` to issue a client-side cookie session. For simplicity, no data is persisted.
 
-Visit [Google Developer Console](https://console.developers.google.com/project) under Project, APIs & Auth, Credentials to get your OAuth2 client credentials. Add `http://localhost:8080/google/callback` as a valid OAuth2 Redirect URL.
+Visit [Google Developer Console](https://console.cloud.google.com) under Project, APIs, Credentials to get your OAuth2 client credentials. Add `http://localhost:8080/google/callback` as a valid OAuth2 Redirect URL.
 
 <img src="https://storage.googleapis.com/dghubble/google-valid-callback.png">
 

--- a/examples/google/README.md
+++ b/examples/google/README.md
@@ -36,6 +36,6 @@ Here's what the flow looks like.
 
 1. The "Login with Google" link to the login handler directs the user to the Google OAuth2 Auth URL to obtain a permission grant.
 2. The redirection URI (callback handler) receives the OAuth2 callback, verifies the state parameter, and obtains a Token.
-3. The success `ContextHandler` is called with a `Context` which contains the Google Token and verified Google Userinfoplus struct.
+3. The success `http.Handler` is called with a `Context` which contains the Google Token and verified Google Userinfoplus struct.
 4. In this example, that User is read and used to issue a signed cookie session.
 

--- a/examples/twitter/README.md
+++ b/examples/twitter/README.md
@@ -34,6 +34,6 @@ Here's what the flow looks like.
 
 1. Clicking the "Login with Twitter" link to the login handler redirects the user to the Twitter OAuth1 Authorization page to obtain a permission grant.
 2. The callback handler receives the OAuth1 callback and obtains an access token.
-3. The success `ContextHandler` is called with a `Context` which contains the Twitter access token and verified Twitter User struct.
+3. The success `http.Handler` is called with a `Context` which contains the Twitter access token and verified Twitter User struct.
 4. In this example, that User is read and used to issue a signed cookie session.
 

--- a/facebook/context.go
+++ b/facebook/context.go
@@ -1,9 +1,8 @@
 package facebook
 
 import (
+	"context"
 	"fmt"
-
-	"golang.org/x/net/context"
 )
 
 // unexported key type prevents collisions

--- a/facebook/context_test.go
+++ b/facebook/context_test.go
@@ -1,10 +1,10 @@
 package facebook
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 )
 
 func TestContextUser(t *testing.T) {

--- a/facebook/login.go
+++ b/facebook/login.go
@@ -4,10 +4,8 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/dghubble/ctxh"
 	"github.com/dghubble/gologin"
 	oauth2Login "github.com/dghubble/gologin/oauth2"
-	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 )
 
@@ -24,13 +22,13 @@ var (
 // state params differently, write a ContextHandler which sets the ctx state,
 // using oauth2 WithState(ctx, state) since it is required by LoginHandler
 // and CallbackHandler.
-func StateHandler(config gologin.CookieConfig, success ctxh.ContextHandler) ctxh.ContextHandler {
+func StateHandler(config gologin.CookieConfig, success http.Handler) http.Handler {
 	return oauth2Login.StateHandler(config, success)
 }
 
 // LoginHandler handles Facebook login requests by reading the state value
 // from the ctx and redirecting requests to the AuthURL with that state value.
-func LoginHandler(config *oauth2.Config, failure ctxh.ContextHandler) ctxh.ContextHandler {
+func LoginHandler(config *oauth2.Config, failure http.Handler) http.Handler {
 	return oauth2Login.LoginHandler(config, failure)
 }
 
@@ -38,7 +36,7 @@ func LoginHandler(config *oauth2.Config, failure ctxh.ContextHandler) ctxh.Conte
 // Facebook access token and User to the ctx. If authentication succeeds,
 // handling delegates to the success handler, otherwise to the failure
 // handler.
-func CallbackHandler(config *oauth2.Config, success, failure ctxh.ContextHandler) ctxh.ContextHandler {
+func CallbackHandler(config *oauth2.Config, success, failure http.Handler) http.Handler {
 	success = facebookHandler(config, success, failure)
 	return oauth2Login.CallbackHandler(config, success, failure)
 }
@@ -47,15 +45,16 @@ func CallbackHandler(config *oauth2.Config, success, failure ctxh.ContextHandler
 // to get the corresponding Facebook User. If successful, the user is added to
 // the ctx and the success handler is called. Otherwise, the failure handler
 // is called.
-func facebookHandler(config *oauth2.Config, success, failure ctxh.ContextHandler) ctxh.ContextHandler {
+func facebookHandler(config *oauth2.Config, success, failure http.Handler) http.Handler {
 	if failure == nil {
 		failure = gologin.DefaultFailureHandler
 	}
-	fn := func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	fn := func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
 		token, err := oauth2Login.TokenFromContext(ctx)
 		if err != nil {
 			ctx = gologin.WithError(ctx, err)
-			failure.ServeHTTP(ctx, w, req)
+			failure.ServeHTTP(w, req.WithContext(ctx))
 			return
 		}
 		httpClient := config.Client(ctx, token)
@@ -64,13 +63,13 @@ func facebookHandler(config *oauth2.Config, success, failure ctxh.ContextHandler
 		err = validateResponse(user, resp, err)
 		if err != nil {
 			ctx = gologin.WithError(ctx, err)
-			failure.ServeHTTP(ctx, w, req)
+			failure.ServeHTTP(w, req.WithContext(ctx))
 			return
 		}
 		ctx = WithUser(ctx, user)
-		success.ServeHTTP(ctx, w, req)
+		success.ServeHTTP(w, req.WithContext(ctx))
 	}
-	return ctxh.ContextHandlerFunc(fn)
+	return http.HandlerFunc(fn)
 }
 
 // validateResponse returns an error if the given Facebook User, raw

--- a/facebook/login.go
+++ b/facebook/login.go
@@ -19,7 +19,7 @@ var (
 // and to a (short-lived) state cookie issued to the requester.
 //
 // Implements OAuth 2 RFC 6749 10.12 CSRF Protection. If you wish to issue
-// state params differently, write a ContextHandler which sets the ctx state,
+// state params differently, write a http.Handler which sets the ctx state,
 // using oauth2 WithState(ctx, state) since it is required by LoginHandler
 // and CallbackHandler.
 func StateHandler(config gologin.CookieConfig, success http.Handler) http.Handler {
@@ -41,7 +41,7 @@ func CallbackHandler(config *oauth2.Config, success, failure http.Handler) http.
 	return oauth2Login.CallbackHandler(config, success, failure)
 }
 
-// facebookHandler is a ContextHandler that gets the OAuth2 Token from the ctx
+// facebookHandler is a http.Handler that gets the OAuth2 Token from the ctx
 // to get the corresponding Facebook User. If successful, the user is added to
 // the ctx and the success handler is called. Otherwise, the failure handler
 // is called.

--- a/github/context.go
+++ b/github/context.go
@@ -1,10 +1,10 @@
 package github
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/google/go-github/github"
-	"golang.org/x/net/context"
 )
 
 // unexported key type prevents collisions

--- a/github/context_test.go
+++ b/github/context_test.go
@@ -1,11 +1,11 @@
 package github
 
 import (
+	"context"
 	"testing"
 
 	"github.com/google/go-github/github"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 )
 
 func TestContextUser(t *testing.T) {

--- a/github/login.go
+++ b/github/login.go
@@ -20,7 +20,7 @@ var (
 // and to a (short-lived) state cookie issued to the requester.
 //
 // Implements OAuth 2 RFC 6749 10.12 CSRF Protection. If you wish to issue
-// state params differently, write a ContextHandler which sets the ctx state,
+// state params differently, write a http.Handler which sets the ctx state,
 // using oauth2 WithState(ctx, state) since it is required by LoginHandler
 // and CallbackHandler.
 func StateHandler(config gologin.CookieConfig, success http.Handler) http.Handler {
@@ -41,7 +41,7 @@ func CallbackHandler(config *oauth2.Config, success, failure http.Handler) http.
 	return oauth2Login.CallbackHandler(config, success, failure)
 }
 
-// githubHandler is a ContextHandler that gets the OAuth2 Token from the ctx to
+// githubHandler is a http.Handler that gets the OAuth2 Token from the ctx to
 // get the corresponding Github User. If successful, the User is added to the
 // ctx and the success handler is called. Otherwise, the failure handler is
 // called.

--- a/github/login.go
+++ b/github/login.go
@@ -4,11 +4,9 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/dghubble/ctxh"
 	"github.com/dghubble/gologin"
 	oauth2Login "github.com/dghubble/gologin/oauth2"
 	"github.com/google/go-github/github"
-	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 )
 
@@ -25,20 +23,20 @@ var (
 // state params differently, write a ContextHandler which sets the ctx state,
 // using oauth2 WithState(ctx, state) since it is required by LoginHandler
 // and CallbackHandler.
-func StateHandler(config gologin.CookieConfig, success ctxh.ContextHandler) ctxh.ContextHandler {
+func StateHandler(config gologin.CookieConfig, success http.Handler) http.Handler {
 	return oauth2Login.StateHandler(config, success)
 }
 
 // LoginHandler handles Github login requests by reading the state value from
 // the ctx and redirecting requests to the AuthURL with that state value.
-func LoginHandler(config *oauth2.Config, failure ctxh.ContextHandler) ctxh.ContextHandler {
+func LoginHandler(config *oauth2.Config, failure http.Handler) http.Handler {
 	return oauth2Login.LoginHandler(config, failure)
 }
 
 // CallbackHandler handles Github redirection URI requests and adds the Github
 // access token and User to the ctx. If authentication succeeds, handling
 // delegates to the success handler, otherwise to the failure handler.
-func CallbackHandler(config *oauth2.Config, success, failure ctxh.ContextHandler) ctxh.ContextHandler {
+func CallbackHandler(config *oauth2.Config, success, failure http.Handler) http.Handler {
 	success = githubHandler(config, success, failure)
 	return oauth2Login.CallbackHandler(config, success, failure)
 }
@@ -47,15 +45,16 @@ func CallbackHandler(config *oauth2.Config, success, failure ctxh.ContextHandler
 // get the corresponding Github User. If successful, the User is added to the
 // ctx and the success handler is called. Otherwise, the failure handler is
 // called.
-func githubHandler(config *oauth2.Config, success, failure ctxh.ContextHandler) ctxh.ContextHandler {
+func githubHandler(config *oauth2.Config, success, failure http.Handler) http.Handler {
 	if failure == nil {
 		failure = gologin.DefaultFailureHandler
 	}
-	fn := func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	fn := func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
 		token, err := oauth2Login.TokenFromContext(ctx)
 		if err != nil {
 			ctx = gologin.WithError(ctx, err)
-			failure.ServeHTTP(ctx, w, req)
+			failure.ServeHTTP(w, req.WithContext(ctx))
 			return
 		}
 		httpClient := config.Client(ctx, token)
@@ -64,13 +63,13 @@ func githubHandler(config *oauth2.Config, success, failure ctxh.ContextHandler) 
 		err = validateResponse(user, resp, err)
 		if err != nil {
 			ctx = gologin.WithError(ctx, err)
-			failure.ServeHTTP(ctx, w, req)
+			failure.ServeHTTP(w, req.WithContext(ctx))
 			return
 		}
 		ctx = WithUser(ctx, user)
-		success.ServeHTTP(ctx, w, req)
+		success.ServeHTTP(w, req.WithContext(ctx))
 	}
-	return ctxh.ContextHandlerFunc(fn)
+	return http.HandlerFunc(fn)
 }
 
 // validateResponse returns an error if the given Github user, raw

--- a/github/login_test.go
+++ b/github/login_test.go
@@ -20,6 +20,7 @@ func TestGithubHandler(t *testing.T) {
 	expectedUser := &github.User{ID: github.Int(917408), Name: github.String("Alyssa Hacker")}
 	proxyClient, server := newGithubTestServer(jsonData)
 	defer server.Close()
+
 	// oauth2 Client will use the proxy client's base Transport
 	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, proxyClient)
 	anyToken := &oauth2.Token{AccessToken: "any-token"}

--- a/google/context.go
+++ b/google/context.go
@@ -1,9 +1,9 @@
 package google
 
 import (
+	"context"
 	"fmt"
 
-	"golang.org/x/net/context"
 	google "google.golang.org/api/oauth2/v2"
 )
 

--- a/google/context_test.go
+++ b/google/context_test.go
@@ -1,10 +1,10 @@
 package google
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 	google "google.golang.org/api/oauth2/v2"
 )
 

--- a/google/login.go
+++ b/google/login.go
@@ -21,7 +21,7 @@ var (
 // and to a (short-lived) state cookie issued to the requester.
 //
 // Implements OAuth 2 RFC 6749 10.12 CSRF Protection. If you wish to issue
-// state params differently, write a ContextHandler which sets the ctx state,
+// state params differently, write a http.Handler which sets the ctx state,
 // using oauth2 WithState(ctx, state) since it is required by LoginHandler
 // and CallbackHandler.
 func StateHandler(config gologin.CookieConfig, success http.Handler) http.Handler {
@@ -42,7 +42,7 @@ func CallbackHandler(config *oauth2.Config, success, failure http.Handler) http.
 	return oauth2Login.CallbackHandler(config, success, failure)
 }
 
-// googleHandler is a ContextHandler that gets the OAuth2 Token from the ctx
+// googleHandler is a http.Handler that gets the OAuth2 Token from the ctx
 // to get the corresponding Google Userinfoplus. If successful, the user info
 // is added to the ctx and the success handler is called. Otherwise, the
 // failure handler is called.

--- a/google/login_test.go
+++ b/google/login_test.go
@@ -1,17 +1,16 @@
 package google
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
-	"github.com/dghubble/ctxh"
 	"github.com/dghubble/gologin"
 	oauth2Login "github.com/dghubble/gologin/oauth2"
 	"github.com/dghubble/gologin/testutils"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 	google "google.golang.org/api/oauth2/v2"
 )
@@ -27,7 +26,8 @@ func TestGoogleHandler(t *testing.T) {
 	ctx = oauth2Login.WithToken(ctx, anyToken)
 
 	config := &oauth2.Config{}
-	success := func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	success := func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
 		googleUser, err := UserFromContext(ctx)
 		assert.Nil(t, err)
 		// assert required fields; Userinfoplus contains other raw response info
@@ -42,17 +42,18 @@ func TestGoogleHandler(t *testing.T) {
 	// - google Userinfoplus is obtained from the Google API
 	// - success handler is called
 	// - google Userinfoplus is added to the ctx of the success handler
-	googleHandler := googleHandler(config, ctxh.ContextHandlerFunc(success), failure)
+	googleHandler := googleHandler(config, http.HandlerFunc(success), failure)
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/", nil)
-	googleHandler.ServeHTTP(ctx, w, req)
+	googleHandler.ServeHTTP(w, req.WithContext(ctx))
 	assert.Equal(t, "success handler called", w.Body.String())
 }
 
 func TestGoogleHandler_MissingCtxToken(t *testing.T) {
 	config := &oauth2.Config{}
 	success := testutils.AssertSuccessNotCalled(t)
-	failure := func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	failure := func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
 		err := gologin.ErrorFromContext(ctx)
 		if assert.NotNil(t, err) {
 			assert.Equal(t, "oauth2: Context missing Token", err.Error())
@@ -63,10 +64,10 @@ func TestGoogleHandler_MissingCtxToken(t *testing.T) {
 	// GoogleHandler called without Token in ctx, assert that:
 	// - failure handler is called
 	// - error about ctx missing token is added to the failure handler ctx
-	googleHandler := googleHandler(config, success, ctxh.ContextHandlerFunc(failure))
+	googleHandler := googleHandler(config, success, http.HandlerFunc(failure))
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/", nil)
-	googleHandler.ServeHTTP(context.Background(), w, req)
+	googleHandler.ServeHTTP(w, req)
 	assert.Equal(t, "failure handler called", w.Body.String())
 }
 
@@ -80,7 +81,8 @@ func TestGoogleHandler_ErrorGettingUser(t *testing.T) {
 
 	config := &oauth2.Config{}
 	success := testutils.AssertSuccessNotCalled(t)
-	failure := func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	failure := func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
 		err := gologin.ErrorFromContext(ctx)
 		if assert.NotNil(t, err) {
 			assert.Equal(t, ErrUnableToGetGoogleUser, err)
@@ -91,10 +93,10 @@ func TestGoogleHandler_ErrorGettingUser(t *testing.T) {
 	// GoogleHandler cannot get Google User, assert that:
 	// - failure handler is called
 	// - error cannot get Google User added to the failure handler ctx
-	googleHandler := googleHandler(config, success, ctxh.ContextHandlerFunc(failure))
+	googleHandler := googleHandler(config, success, http.HandlerFunc(failure))
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/", nil)
-	googleHandler.ServeHTTP(ctx, w, req)
+	googleHandler.ServeHTTP(w, req.WithContext(ctx))
 	assert.Equal(t, "failure handler called", w.Body.String())
 }
 

--- a/oauth1/context.go
+++ b/oauth1/context.go
@@ -1,9 +1,11 @@
 package oauth1
 
 import (
+	"context"
 	"fmt"
+	"net/http"
 
-	"golang.org/x/net/context"
+	olib "github.com/dghubble/oauth1"
 )
 
 // unexported key type prevents collisions
@@ -50,4 +52,12 @@ func AccessTokenFromContext(ctx context.Context) (string, string, error) {
 		return "", "", fmt.Errorf("oauth1: Context missing access token or secret")
 	}
 	return accessToken, accessSecret, nil
+}
+
+// WithHTTPClient returns a handler that sets the provided HttpClient in the request context.
+func WithHTTPClient(client *http.Client, next http.Handler) http.Handler {
+	fn := func(w http.ResponseWriter, req *http.Request) {
+		next.ServeHTTP(w, req.WithContext(context.WithValue(req.Context(), olib.HTTPClient, client)))
+	}
+	return http.HandlerFunc(fn)
 }

--- a/oauth1/context.go
+++ b/oauth1/context.go
@@ -3,9 +3,6 @@ package oauth1
 import (
 	"context"
 	"fmt"
-	"net/http"
-
-	olib "github.com/dghubble/oauth1"
 )
 
 // unexported key type prevents collisions
@@ -52,12 +49,4 @@ func AccessTokenFromContext(ctx context.Context) (string, string, error) {
 		return "", "", fmt.Errorf("oauth1: Context missing access token or secret")
 	}
 	return accessToken, accessSecret, nil
-}
-
-// WithHTTPClient returns a handler that sets the provided HttpClient in the request context.
-func WithHTTPClient(client *http.Client, next http.Handler) http.Handler {
-	fn := func(w http.ResponseWriter, req *http.Request) {
-		next.ServeHTTP(w, req.WithContext(context.WithValue(req.Context(), olib.HTTPClient, client)))
-	}
-	return http.HandlerFunc(fn)
 }

--- a/oauth1/context_test.go
+++ b/oauth1/context_test.go
@@ -1,10 +1,10 @@
 package oauth1
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 )
 
 func TestContextRequestToken(t *testing.T) {

--- a/oauth2/context.go
+++ b/oauth2/context.go
@@ -1,9 +1,9 @@
 package oauth2
 
 import (
+	"context"
 	"fmt"
 
-	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 )
 

--- a/oauth2/context_test.go
+++ b/oauth2/context_test.go
@@ -1,10 +1,10 @@
 package oauth2
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 )
 

--- a/oauth2/login.go
+++ b/oauth2/login.go
@@ -21,7 +21,7 @@ var (
 // and to a (short-lived) state cookie issued to the requester.
 //
 // Implements OAuth 2 RFC 6749 10.12 CSRF Protection. If you wish to issue
-// state params differently, write a ContextHandler which sets the ctx state,
+// state params differently, write a http.Handler which sets the ctx state,
 // using oauth2 WithState(ctx, state) since it is required by LoginHandler
 // and CallbackHandler.
 func StateHandler(config gologin.CookieConfig, success http.Handler) http.Handler {

--- a/test
+++ b/test
@@ -1,15 +1,22 @@
 #!/usr/bin/env bash
- set -e
+set -e
 
 PKGS=$(go list ./... | grep -v /examples)
-FORMATTABLE="$(find . -maxdepth 1 -type d)"
+FMT_DIRS=$(ls -d */)
+FMT_FILES=$(find . -maxdepth 1 | grep "\.go")
 LINTABLE=$(go list ./...)
 
 go test $PKGS -cover
 go vet $PKGS
 
 echo "Checking gofmt..."
-fmtRes=$(gofmt -l $FORMATTABLE)
+fmtRes=$(gofmt -l $FMT_DIRS)
+if [ -n "${fmtRes}" ]; then
+  echo -e "gofmt checking failed:\n${fmtRes}"
+  exit 2
+fi
+
+fmtRes=$(gofmt -l $FMT_FILES)
 if [ -n "${fmtRes}" ]; then
   echo -e "gofmt checking failed:\n${fmtRes}"
   exit 2

--- a/testutils/asserts.go
+++ b/testutils/asserts.go
@@ -10,18 +10,18 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// AssertSuccessNotCalled is a success ContextHandler that fails if called.
+// AssertSuccessNotCalled is a success http.Handler that fails if called.
 func AssertSuccessNotCalled(t *testing.T) http.Handler {
 	fn := func(w http.ResponseWriter, req *http.Request) {
-		assert.Fail(t, "unexpected call to success ContextHandler")
+		assert.Fail(t, "unexpected call to success Handler")
 	}
 	return http.HandlerFunc(fn)
 }
 
-// AssertFailureNotCalled is a failure ContextHandler that fails if called.
+// AssertFailureNotCalled is a failure http.Handler that fails if called.
 func AssertFailureNotCalled(t *testing.T) http.Handler {
 	fn := func(w http.ResponseWriter, req *http.Request) {
-		assert.Fail(t, "unexpected call to failure ContextHandler")
+		assert.Fail(t, "unexpected call to failure Handler")
 	}
 	return http.HandlerFunc(fn)
 }

--- a/testutils/asserts.go
+++ b/testutils/asserts.go
@@ -7,25 +7,23 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/dghubble/ctxh"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 )
 
 // AssertSuccessNotCalled is a success ContextHandler that fails if called.
-func AssertSuccessNotCalled(t *testing.T) ctxh.ContextHandler {
-	fn := func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+func AssertSuccessNotCalled(t *testing.T) http.Handler {
+	fn := func(w http.ResponseWriter, req *http.Request) {
 		assert.Fail(t, "unexpected call to success ContextHandler")
 	}
-	return ctxh.ContextHandlerFunc(fn)
+	return http.HandlerFunc(fn)
 }
 
 // AssertFailureNotCalled is a failure ContextHandler that fails if called.
-func AssertFailureNotCalled(t *testing.T) ctxh.ContextHandler {
-	fn := func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+func AssertFailureNotCalled(t *testing.T) http.Handler {
+	fn := func(w http.ResponseWriter, req *http.Request) {
 		assert.Fail(t, "unexpected call to failure ContextHandler")
 	}
-	return ctxh.ContextHandlerFunc(fn)
+	return http.HandlerFunc(fn)
 }
 
 // AssertBodyString asserts that a Request Body matches the expected string.

--- a/tumblr/context.go
+++ b/tumblr/context.go
@@ -1,9 +1,8 @@
 package tumblr
 
 import (
+	"context"
 	"fmt"
-
-	"golang.org/x/net/context"
 )
 
 // unexported key type prevents collisions

--- a/tumblr/login.go
+++ b/tumblr/login.go
@@ -35,7 +35,7 @@ func CallbackHandler(config *oauth1.Config, cookieConfig gologin.CookieConfig, s
 	return oauth1Login.CookieTempHandler(cookieConfig, success, failure)
 }
 
-// tumblrHandler is a ContextHandler that gets the OAuth1 access token from
+// tumblrHandler is a http.Handler that gets the OAuth1 access token from
 // the ctx and obtains the Tumblr User. If successful, the User is added to
 // the ctx and the success handler is called. Otherwise, the failure handler
 // is called.

--- a/tumblr/login.go
+++ b/tumblr/login.go
@@ -4,11 +4,9 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/dghubble/ctxh"
 	"github.com/dghubble/gologin"
 	oauth1Login "github.com/dghubble/gologin/oauth1"
 	"github.com/dghubble/oauth1"
-	"golang.org/x/net/context"
 )
 
 // Tumblr login errors
@@ -19,7 +17,7 @@ var (
 // LoginHandler handles Tumblr login requests by obtaining a request token,
 // setting a temporary token secret cookie, and redirecting to the
 // authorization URL.
-func LoginHandler(config *oauth1.Config, cookieConfig gologin.CookieConfig, failure ctxh.ContextHandler) ctxh.ContextHandler {
+func LoginHandler(config *oauth1.Config, cookieConfig gologin.CookieConfig, failure http.Handler) http.Handler {
 	// oauth1.LoginHandler -> oauth1.CookieTempHander -> oauth1.AuthRedirectHandler
 	success := oauth1Login.AuthRedirectHandler(config, failure)
 	success = oauth1Login.CookieTempHandler(cookieConfig, success, failure)
@@ -30,7 +28,7 @@ func LoginHandler(config *oauth1.Config, cookieConfig gologin.CookieConfig, fail
 // and verifier and adding the Tubmlr access token and User to the ctx. If
 // authentication succeeds, handling delegates to the success handler,
 // otherwise to the failure handler.
-func CallbackHandler(config *oauth1.Config, cookieConfig gologin.CookieConfig, success, failure ctxh.ContextHandler) ctxh.ContextHandler {
+func CallbackHandler(config *oauth1.Config, cookieConfig gologin.CookieConfig, success, failure http.Handler) http.Handler {
 	// oauth1.CookieTempHandler -> oauth1.CallbackHandler -> TumblrHandler -> success
 	success = tumblrHandler(config, success, failure)
 	success = oauth1Login.CallbackHandler(config, success, failure)
@@ -41,15 +39,16 @@ func CallbackHandler(config *oauth1.Config, cookieConfig gologin.CookieConfig, s
 // the ctx and obtains the Tumblr User. If successful, the User is added to
 // the ctx and the success handler is called. Otherwise, the failure handler
 // is called.
-func tumblrHandler(config *oauth1.Config, success, failure ctxh.ContextHandler) ctxh.ContextHandler {
+func tumblrHandler(config *oauth1.Config, success, failure http.Handler) http.Handler {
 	if failure == nil {
 		failure = gologin.DefaultFailureHandler
 	}
-	fn := func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	fn := func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
 		accessToken, accessSecret, err := oauth1Login.AccessTokenFromContext(ctx)
 		if err != nil {
 			ctx = gologin.WithError(ctx, err)
-			failure.ServeHTTP(ctx, w, req)
+			failure.ServeHTTP(w, req.WithContext(ctx))
 			return
 		}
 		httpClient := config.Client(ctx, oauth1.NewToken(accessToken, accessSecret))
@@ -58,13 +57,13 @@ func tumblrHandler(config *oauth1.Config, success, failure ctxh.ContextHandler) 
 		err = validateResponse(user, resp, err)
 		if err != nil {
 			ctx = gologin.WithError(ctx, err)
-			failure.ServeHTTP(ctx, w, req)
+			failure.ServeHTTP(w, req.WithContext(ctx))
 			return
 		}
 		ctx = WithUser(ctx, user)
-		success.ServeHTTP(ctx, w, req)
+		success.ServeHTTP(w, req.WithContext(ctx))
 	}
-	return ctxh.ContextHandlerFunc(fn)
+	return http.HandlerFunc(fn)
 }
 
 // validateResponse returns an error if the given Tumblr User, raw

--- a/twitter/context.go
+++ b/twitter/context.go
@@ -1,10 +1,10 @@
 package twitter
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/dghubble/go-twitter/twitter"
-	"golang.org/x/net/context"
 )
 
 // unexported key type prevents collisions

--- a/twitter/login.go
+++ b/twitter/login.go
@@ -34,7 +34,7 @@ func CallbackHandler(config *oauth1.Config, success, failure http.Handler) http.
 	return oauth1Login.EmptyTempHandler(success)
 }
 
-// twitterHandler is a ContextHandler that gets the OAuth1 access token from
+// twitterHandler is a http.Handler that gets the OAuth1 access token from
 // the ctx and calls Twitter verify_credentials to get the corresponding User.
 // If successful, the User is added to the ctx and the success handler is
 // called. Otherwise, the failure handler is called.

--- a/twitter/token_test.go
+++ b/twitter/token_test.go
@@ -7,13 +7,11 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/dghubble/ctxh"
 	"github.com/dghubble/gologin"
 	oauth1Login "github.com/dghubble/gologin/oauth1"
 	"github.com/dghubble/gologin/testutils"
 	"github.com/dghubble/oauth1"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 )
 
 const (
@@ -26,11 +24,10 @@ const (
 func TestTokenHandler(t *testing.T) {
 	proxyClient, _, server := newTwitterVerifyServer(testTwitterUserJSON)
 	defer server.Close()
-	// oauth1 Client will use the proxy client's base Transport
-	ctx := context.WithValue(context.Background(), oauth1.HTTPClient, proxyClient)
 
 	config := &oauth1.Config{}
-	success := func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	success := func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
 		accessToken, accessSecret, err := oauth1Login.AccessTokenFromContext(ctx)
 		assert.Nil(t, err)
 		assert.Equal(t, testTwitterToken, accessToken)
@@ -41,8 +38,9 @@ func TestTokenHandler(t *testing.T) {
 		assert.Equal(t, expectedUserID, user.ID)
 		assert.Equal(t, "1234", user.IDStr)
 	}
-	handler := TokenHandler(config, ctxh.ContextHandlerFunc(success), testutils.AssertFailureNotCalled(t))
-	ts := httptest.NewServer(ctxh.NewHandlerWithContext(ctx, handler))
+	handler := TokenHandler(config, http.HandlerFunc(success), testutils.AssertFailureNotCalled(t))
+	// oauth1 Client will use the proxy client's base Transport
+	ts := httptest.NewServer(oauth1Login.WithHTTPClient(proxyClient, handler))
 	// POST token to server under test
 	resp, err := http.PostForm(ts.URL, url.Values{accessTokenField: {testTwitterToken}, accessTokenSecretField: {testTwitterTokenSecret}})
 	assert.Nil(t, err)
@@ -54,12 +52,11 @@ func TestTokenHandler(t *testing.T) {
 func TestTokenHandler_ErrorVerifyingToken(t *testing.T) {
 	proxyClient, server := testutils.NewErrorServer("Twitter Verify Credentials Down", http.StatusInternalServerError)
 	defer server.Close()
-	// oauth1 Client will use the proxy client's base Transport
-	ctx := context.WithValue(context.Background(), oauth1.HTTPClient, proxyClient)
 
 	config := &oauth1.Config{}
 	handler := TokenHandler(config, testutils.AssertSuccessNotCalled(t), nil)
-	ts := httptest.NewServer(ctxh.NewHandlerWithContext(ctx, handler))
+	// oauth1 Client will use the proxy client's base Transport
+	ts := httptest.NewServer(oauth1Login.WithHTTPClient(proxyClient, handler))
 	// assert that error occurs indicating the Twitter User could not be confirmed
 	resp, _ := http.PostForm(ts.URL, url.Values{accessTokenField: {testTwitterToken}, accessTokenSecretField: {testTwitterTokenSecret}})
 	testutils.AssertBodyString(t, resp.Body, ErrUnableToGetTwitterUser.Error()+"\n")
@@ -68,25 +65,25 @@ func TestTokenHandler_ErrorVerifyingToken(t *testing.T) {
 func TestTokenHandler_ErrorVerifyingTokenPassesError(t *testing.T) {
 	proxyClient, server := testutils.NewErrorServer("Twitter Verify Credentials Down", http.StatusInternalServerError)
 	defer server.Close()
-	// oauth1 Client will use the proxy client's base Transport
-	ctx := context.WithValue(context.Background(), oauth1.HTTPClient, proxyClient)
 
 	config := &oauth1.Config{}
-	failure := func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	failure := func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
 		// assert that error passed through ctx
 		err := gologin.ErrorFromContext(ctx)
 		if assert.Error(t, err) {
 			assert.Equal(t, err, ErrUnableToGetTwitterUser)
 		}
 	}
-	handler := TokenHandler(config, testutils.AssertSuccessNotCalled(t), ctxh.ContextHandlerFunc(failure))
-	ts := httptest.NewServer(ctxh.NewHandlerWithContext(ctx, handler))
+	handler := TokenHandler(config, testutils.AssertSuccessNotCalled(t), http.HandlerFunc(failure))
+	// oauth1 Client will use the proxy client's base Transport
+	ts := httptest.NewServer(oauth1Login.WithHTTPClient(proxyClient, handler))
 	http.PostForm(ts.URL, url.Values{accessTokenField: {testTwitterToken}, accessTokenSecretField: {testTwitterTokenSecret}})
 }
 
 func TestTokenHandler_NonPost(t *testing.T) {
 	config := &oauth1.Config{}
-	ts := httptest.NewServer(ctxh.NewHandler(TokenHandler(config, testutils.AssertSuccessNotCalled(t), nil)))
+	ts := httptest.NewServer(TokenHandler(config, testutils.AssertSuccessNotCalled(t), nil))
 	resp, err := http.Get(ts.URL)
 	assert.Nil(t, err)
 	// assert that default (nil) failure handler returns a 405 Method Not Allowed
@@ -98,20 +95,21 @@ func TestTokenHandler_NonPost(t *testing.T) {
 
 func TestTokenHandler_NonPostPassesError(t *testing.T) {
 	config := &oauth1.Config{}
-	failure := func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	failure := func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
 		// assert that Method not allowed error passed through ctx
 		err := gologin.ErrorFromContext(ctx)
 		if assert.Error(t, err) {
 			assert.Equal(t, err, fmt.Errorf("Method not allowed"))
 		}
 	}
-	ts := httptest.NewServer(ctxh.NewHandler(TokenHandler(config, testutils.AssertSuccessNotCalled(t), ctxh.ContextHandlerFunc(failure))))
+	ts := httptest.NewServer(TokenHandler(config, testutils.AssertSuccessNotCalled(t), http.HandlerFunc(failure)))
 	http.Get(ts.URL)
 }
 
 func TestTokenHandler_InvalidFields(t *testing.T) {
 	config := &oauth1.Config{}
-	ts := httptest.NewServer(ctxh.NewHandler(TokenHandler(config, testutils.AssertSuccessNotCalled(t), nil)))
+	ts := httptest.NewServer(TokenHandler(config, testutils.AssertSuccessNotCalled(t), nil))
 
 	// assert errors occur for different missing POST fields
 	resp, err := http.PostForm(ts.URL, nil)

--- a/twitter/token_test.go
+++ b/twitter/token_test.go
@@ -1,10 +1,12 @@
 package twitter
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/dghubble/gologin"
@@ -25,6 +27,9 @@ func TestTokenHandler(t *testing.T) {
 	proxyClient, _, server := newTwitterVerifyServer(testTwitterUserJSON)
 	defer server.Close()
 
+	// oauth1 Client will use the proxy client's base Transport
+	ctx := context.WithValue(context.Background(), oauth1.HTTPClient, proxyClient)
+
 	config := &oauth1.Config{}
 	success := func(w http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
@@ -37,48 +42,52 @@ func TestTokenHandler(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, expectedUserID, user.ID)
 		assert.Equal(t, "1234", user.IDStr)
+		fmt.Fprintf(w, "success handler called")
 	}
-	handler := TokenHandler(config, http.HandlerFunc(success), testutils.AssertFailureNotCalled(t))
-	// oauth1 Client will use the proxy client's base Transport
-	ts := httptest.NewServer(oauth1Login.WithHTTPClient(proxyClient, handler))
-	// POST token to server under test
-	resp, err := http.PostForm(ts.URL, url.Values{accessTokenField: {testTwitterToken}, accessTokenSecretField: {testTwitterTokenSecret}})
-	assert.Nil(t, err)
-	if assert.NotNil(t, resp) {
-		assert.Equal(t, resp.StatusCode, http.StatusOK)
-	}
+	failure := testutils.AssertFailureNotCalled(t)
+
+	// TokenHandler assert that:
+	// - access token/secret are read from POST
+	// - twitter User is obtained from Twitter API
+	// - success handler is called
+	// - twitter User is added to success handler ctx
+	tokenHandler := TokenHandler(config, http.HandlerFunc(success), failure)
+	w := httptest.NewRecorder()
+	form := url.Values{accessTokenField: {testTwitterToken}, accessTokenSecretField: {testTwitterTokenSecret}}
+	req, _ := http.NewRequest("POST", "/", strings.NewReader(form.Encode()))
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	tokenHandler.ServeHTTP(w, req.WithContext(ctx))
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "success handler called", w.Body.String())
 }
 
 func TestTokenHandler_ErrorVerifyingToken(t *testing.T) {
 	proxyClient, server := testutils.NewErrorServer("Twitter Verify Credentials Down", http.StatusInternalServerError)
 	defer server.Close()
 
-	config := &oauth1.Config{}
-	handler := TokenHandler(config, testutils.AssertSuccessNotCalled(t), nil)
 	// oauth1 Client will use the proxy client's base Transport
-	ts := httptest.NewServer(oauth1Login.WithHTTPClient(proxyClient, handler))
-	// assert that error occurs indicating the Twitter User could not be confirmed
-	resp, _ := http.PostForm(ts.URL, url.Values{accessTokenField: {testTwitterToken}, accessTokenSecretField: {testTwitterTokenSecret}})
-	testutils.AssertBodyString(t, resp.Body, ErrUnableToGetTwitterUser.Error()+"\n")
-}
-
-func TestTokenHandler_ErrorVerifyingTokenPassesError(t *testing.T) {
-	proxyClient, server := testutils.NewErrorServer("Twitter Verify Credentials Down", http.StatusInternalServerError)
-	defer server.Close()
+	ctx := context.WithValue(context.Background(), oauth1.HTTPClient, proxyClient)
 
 	config := &oauth1.Config{}
 	failure := func(w http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
-		// assert that error passed through ctx
 		err := gologin.ErrorFromContext(ctx)
 		if assert.Error(t, err) {
 			assert.Equal(t, err, ErrUnableToGetTwitterUser)
 		}
+		fmt.Fprintf(w, "failure handler called")
 	}
-	handler := TokenHandler(config, testutils.AssertSuccessNotCalled(t), http.HandlerFunc(failure))
-	// oauth1 Client will use the proxy client's base Transport
-	ts := httptest.NewServer(oauth1Login.WithHTTPClient(proxyClient, handler))
-	http.PostForm(ts.URL, url.Values{accessTokenField: {testTwitterToken}, accessTokenSecretField: {testTwitterTokenSecret}})
+
+	// TokenHandler cannot verify Twitter credentials and get User, assert that:
+	// - failure handler is called
+	// - error is added to the failure handler context
+	tokenHandler := TokenHandler(config, testutils.AssertSuccessNotCalled(t), http.HandlerFunc(failure))
+	w := httptest.NewRecorder()
+	form := url.Values{accessTokenField: {testTwitterToken}, accessTokenSecretField: {testTwitterTokenSecret}}
+	req, _ := http.NewRequest("POST", "/", strings.NewReader(form.Encode()))
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	tokenHandler.ServeHTTP(w, req.WithContext(ctx))
+	assert.Equal(t, "failure handler called", w.Body.String())
 }
 
 func TestTokenHandler_NonPost(t *testing.T) {


### PR DESCRIPTION
If you're using Go 1.7+ and the new `context`, you may wish to start using this release candidate.

```
# glide.yaml
- package: github.com/dghubble/gologin
  version: v2.0.0-rc1
```

Go 1.8 is nearly finalized and Fedora/Debian users should have Go 1.7 by default too. Its probably close to transition time unless there are objections. Aiming to merge when 1.8 release candidate goes out. Go 1.6 support will be dropped in v2.0.0 and continue for a short while as v1.0.* releases.

Special thanks to @TamalSaha for his commits.