### PR TITLE
Fix Github GetUsers API call to include context

### DIFF
--- a/github/login.go
+++ b/github/login.go
@@ -59,7 +59,7 @@ func githubHandler(config *oauth2.Config, success, failure http.Handler) http.Ha
 		}
 		httpClient := config.Client(ctx, token)
 		githubClient := github.NewClient(httpClient)
-		user, resp, err := githubClient.Users.Get("")
+		user, resp, err := githubClient.Users.Get(ctx, "")
 		err = validateResponse(user, resp, err)
 		if err != nil {
 			ctx = gologin.WithError(ctx, err)


### PR DESCRIPTION
Fixes a breaking change in the Github API introduced by https://github.com/google/go-github/pull/529. No changelog or releases. :/

Caught by internal CI.
