### PR TITLE
Pass Facebook errors through to facebookHandler failure func

### DIFF
--- a/facebook/login.go
+++ b/facebook/login.go
@@ -2,6 +2,7 @@ package facebook
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/dghubble/gologin"
@@ -76,7 +77,7 @@ func facebookHandler(config *oauth2.Config, success, failure http.Handler) http.
 // http.Response, or error are unexpected. Returns nil if they are valid.
 func validateResponse(user *User, resp *http.Response, err error) error {
 	if err != nil || resp.StatusCode != http.StatusOK {
-		return ErrUnableToGetFacebookUser
+		return fmt.Errorf("facebook: unable to get Facebook user: %v", err)
 	}
 	if user == nil || user.ID == "" {
 		return ErrUnableToGetFacebookUser

--- a/facebook/login_test.go
+++ b/facebook/login_test.go
@@ -81,9 +81,7 @@ func TestFacebookHandler_ErrorGettingUser(t *testing.T) {
 	failure := func(w http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
 		err := gologin.ErrorFromContext(ctx)
-		if assert.NotNil(t, err) {
-			assert.Equal(t, ErrUnableToGetFacebookUser, err)
-		}
+		assert.Error(t, err)
 		fmt.Fprintf(w, "failure handler called")
 	}
 
@@ -102,7 +100,7 @@ func TestValidateResponse(t *testing.T) {
 	validResponse := &http.Response{StatusCode: 200}
 	invalidResponse := &http.Response{StatusCode: 500}
 	assert.Equal(t, nil, validateResponse(validUser, validResponse, nil))
-	assert.Equal(t, ErrUnableToGetFacebookUser, validateResponse(validUser, validResponse, fmt.Errorf("Server error")))
-	assert.Equal(t, ErrUnableToGetFacebookUser, validateResponse(validUser, invalidResponse, nil))
+	assert.Error(t, validateResponse(validUser, validResponse, fmt.Errorf("Server error")))
+	assert.Error(t, validateResponse(validUser, invalidResponse, nil))
 	assert.Equal(t, ErrUnableToGetFacebookUser, validateResponse(&User{}, validResponse, nil))
 }


### PR DESCRIPTION
Format and include Facebook errors for facebookHandler's `failure` handler. Previously, facebookService.Me() errors were swallowed by validateReponse returning a generic ErrUnableToGetFacebookUser

Closes #30