### PR TITLE
github: support enterprise instances

### DIFF
--- a/github/server_test.go
+++ b/github/server_test.go
@@ -8,12 +8,14 @@ import (
 	"github.com/dghubble/gologin/testutils"
 )
 
-// newGithubTestServer returns a new httptest.Server which mocks the Github
-// user endpoint and a client which proxies requests to the server. The server
-// responds with the given json data. The caller must close the server.
-func newGithubTestServer(jsonData string) (*http.Client, *httptest.Server) {
+// newGithubTestServer returns a new httptest.Server which mocks the Github user
+// endpoint and a client which proxies requests to the server. The server
+// responds with the given json data. The caller must close the server. The
+// routePrefix parameter specifies an optional route prefix that should be set
+// to the API root route (empty for github.com, "/api/v3" for GHE).
+func newGithubTestServer(routePrefix, jsonData string) (*http.Client, *httptest.Server) {
 	client, mux, server := testutils.TestServer()
-	mux.HandleFunc("/user", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(routePrefix+"/user", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprintf(w, jsonData)
 	})


### PR DESCRIPTION
Thanks for making a wonderful library!

This PR adds support for GitHub Enterprise instances. It looks at the AuthURL endpoint to infer whether the GitHub instance is github.com or an enterprise instance.