### PR TITLE
Update travis.yml for Go 1.11, remove 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language: go
 go:
-  - 1.8
   - 1.9
-  - "1.10"
+  - "1.10.x"
+  - "1.11.x"
   - tip
 matrix:
   allow_failures:
     - go: tip
 install:
   - go get golang.org/x/lint/golint 
-  - go get -v -t ./...
+  - go get -v -t $(go list ./... | grep -v /examples)
 script:
   - ./test


### PR DESCRIPTION
* Skip downloading dependency packages for example packages since examples dependencies use a 1.11+ feature

related: https://github.com/dghubble/sessions/pull/5