### PR TITLE
Update .travis.yml to add Go v1.13 and v1.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: go
 go:
-  - "1.10.x"
-  - "1.11.x"
   - "1.12.x"
+  - "1.13.x"
+  - "1.14.x"
 install:
-  - go get golang.org/x/lint/golint 
-  - go get -v -t $(go list ./... | grep -v /examples)
+  - go get golang.org/x/lint/golint
 script:
   - make
 notification:

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+export GO111MODULE=on
+
 .PHONY: all
 all: test vet lint fmt
 

--- a/oauth1/login_test.go
+++ b/oauth1/login_test.go
@@ -139,7 +139,7 @@ func TestAuthRedirectHandler_AuthorizationURL(t *testing.T) {
 		ctx := req.Context()
 		err := gologin.ErrorFromContext(ctx)
 		if assert.NotNil(t, err) {
-			assert.Equal(t, "parse %gh&%ij: invalid URL escape \"%gh\"", err.Error())
+			assert.Contains(t, err.Error(), "invalid URL escape \"%gh\"")
 		}
 		fmt.Fprintf(w, "failure handler called")
 	}


### PR DESCRIPTION
* url.Parse quotes URLs in errors in Go v1.14. Update tests to assert errors contain desired messages, rather than exact equality
* Drop Go v1.10 and v1.11 from the test matrix