### PR TITLE
Add release notes for v2.3.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,11 @@ Notable changes between releases.
 
 ## Latest
 
+## v2.3.0
+
+* Update `google.golang.org/api` to v0.22.0 ([#40](https://github.com/dghubble/gologin/pull/40))
+  * Google API renamed `Userinfoplus` to `Userinfo`
+
 ## v2.2.0
 
 * Suffix packages with `/v2` to provide Go module support ([#37](https://github.com/dghubble/gologin/pull/37))


### PR DESCRIPTION
* Tag a release so auto-updates of Google APIs can move forward