### PR TITLE
Add a section about retrieving access token in GitHub example

### DIFF
--- a/examples/github/README.md
+++ b/examples/github/README.md
@@ -33,3 +33,15 @@ Here's what the flow looks like.
 3. The success `http.Handler` is called with a `Context` which contains the Github Token and verified Github User struct.
 4. In this example, that User is read and used to issue a signed cookie session.
 
+### Retrieving the access token
+
+To retrieve the access token for further calls to the GitHub API use the lower level `oauth2` module with the `Context` object:
+```
+import (
+  oauth2Login "github.com/dghubble/gologin/v2/oauth2"
+)
+
+...
+
+token, err := oauth2Login.TokenFromContext(ctx)
+```


### PR DESCRIPTION
There is no explanation about how to retrieve the user's access token after authentication succeeds. Add a short code fragment to the README for retrieving the token.