### PR TITLE
Bump github.com/dghubble/oauth1 from v0.7.0 to v0.7.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/dghubble/go-twitter v0.0.0-20210609183100-2fdbf421508e
-	github.com/dghubble/oauth1 v0.7.0
+	github.com/dghubble/oauth1 v0.7.1
 	github.com/dghubble/sling v1.4.0
 	github.com/google/go-github/v41 v41.0.0
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,8 @@ github.com/dghubble/go-twitter v0.0.0-20210609183100-2fdbf421508e h1:o0sI/cfhAXd
 github.com/dghubble/go-twitter v0.0.0-20210609183100-2fdbf421508e/go.mod h1:xfg4uS5LEzOj8PgZV7SQYRHbG7jPUnelEiaAVJxmhJE=
 github.com/dghubble/oauth1 v0.7.0 h1:AlpZdbRiJM4XGHIlQ8BuJ/wlpGwFEJNnB4Mc+78tA/w=
 github.com/dghubble/oauth1 v0.7.0/go.mod h1:8pFdfPkv/jr8mkChVbNVuJ0suiHe278BtWI4Tk1ujxk=
+github.com/dghubble/oauth1 v0.7.1 h1:JjbOVSVVkms9A4h/sTQy5Jb2nFuAAVb2qVYgenJPyrE=
+github.com/dghubble/oauth1 v0.7.1/go.mod h1:0eEzON0UY/OLACQrmnjgJjmvCGXzjBCsZqL1kWDXtF0=
 github.com/dghubble/sling v1.3.0/go.mod h1:XXShWaBWKzNLhu2OxikSNFrlsvowtz4kyRuXUG7oQKY=
 github.com/dghubble/sling v1.4.0 h1:/n8MRosVTthvMbwlNZgLx579OGVjUOy3GNEv5BIqAWY=
 github.com/dghubble/sling v1.4.0/go.mod h1:0r40aNsU9EdDUVBNhfCstAtFgutjgJGYbO1oNzkMoM8=

--- a/oauth1/login_test.go
+++ b/oauth1/login_test.go
@@ -14,6 +14,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const (
+	expectedOAuth1Error = "oauth1: invalid status 500: OAuth1 Server Error\n"
+)
+
 // LoginHandler
 
 func TestLoginHandler(t *testing.T) {
@@ -68,7 +72,7 @@ func TestLoginHandler_RequestTokenError(t *testing.T) {
 		err := gologin.ErrorFromContext(ctx)
 		if assert.NotNil(t, err) {
 			// first validation in OAuth1 impl failed
-			assert.Equal(t, "oauth1: Server returned status 500", err.Error())
+			assert.Equal(t, expectedOAuth1Error, err.Error())
 		}
 		fmt.Fprintf(w, "failure handler called")
 	}
@@ -254,7 +258,7 @@ func TestCallbackHandler_AccessTokenError(t *testing.T) {
 		err := gologin.ErrorFromContext(ctx)
 		if assert.NotNil(t, err) {
 			// first validation in OAuth1 impl failed
-			assert.Equal(t, "oauth1: Server returned status 500", err.Error())
+			assert.Equal(t, expectedOAuth1Error, err.Error())
 		}
 		fmt.Fprintf(w, "failure handler called")
 	}


### PR DESCRIPTION
* gologin tests were relying on specific error messaging, which changed in v0.7.1