### PR TITLE
Added authCodeOptions to LoginHandler to allow for passing in additional params to the auth url.

### DIFF
--- a/google/login.go
+++ b/google/login.go
@@ -30,8 +30,8 @@ func StateHandler(config gologin.CookieConfig, success http.Handler) http.Handle
 
 // LoginHandler handles Google login requests by reading the state value from
 // the ctx and redirecting requests to the AuthURL with that state value.
-func LoginHandler(config *oauth2.Config, failure http.Handler) http.Handler {
-	return oauth2Login.LoginHandler(config, failure)
+func LoginHandler(config *oauth2.Config, failure http.Handler, authCodeOptions ...oauth2.AuthCodeOption) http.Handler {
+	return oauth2Login.LoginHandler(config, failure, authCodeOptions...)
 }
 
 // CallbackHandler handles Google redirection URI requests and adds the Google

--- a/oauth2/login.go
+++ b/oauth2/login.go
@@ -44,7 +44,7 @@ func StateHandler(config gologin.CookieConfig, success http.Handler) http.Handle
 
 // LoginHandler handles OAuth2 login requests by reading the state value from
 // the ctx and redirecting requests to the AuthURL with that state value.
-func LoginHandler(config *oauth2.Config, failure http.Handler) http.Handler {
+func LoginHandler(config *oauth2.Config, failure http.Handler, authCodeOptions ...oauth2.AuthCodeOption) http.Handler {
 	if failure == nil {
 		failure = gologin.DefaultFailureHandler
 	}
@@ -56,7 +56,7 @@ func LoginHandler(config *oauth2.Config, failure http.Handler) http.Handler {
 			failure.ServeHTTP(w, req.WithContext(ctx))
 			return
 		}
-		authURL := config.AuthCodeURL(state)
+		authURL := config.AuthCodeURL(state, authCodeOptions...)
 		http.Redirect(w, req, authURL, http.StatusFound)
 	}
 	return http.HandlerFunc(fn)


### PR DESCRIPTION
This useful for cases such as setting the prompt field for Google Oauth - https://developers.google.com/identity/protocols/oauth2/web-server#userconsentprompt