### PR TITLE
Add SameSite attribute to the OAuth2 state cookie

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,11 @@ Notable changes between releases.
 
 ## Latest
 
+* Add `SameSite` field to the oauth2 state `CookieConfig` ([#112](https://github.com/dghubble/gologin/pull/112))
+  * Set `SameSiteLaxMode` in `DefaultCookieConfig` and `DebugOnlyCookieConfig`
+* Raise the `MaxAge` in `DefaultCookieConfig` and `DebugOnlyCookieConfig`
+  * Allow 10 min for users to complete the authorization flow
+
 ## v2.3.1
 
 * Update minimum Go version from v1.17 to v1.18 ([#116](https://github.com/dghubble/gologin/pull/116))

--- a/config.go
+++ b/config.go
@@ -1,5 +1,7 @@
 package gologin
 
+import "net/http"
+
 // CookieConfig configures http.Cookie creation.
 type CookieConfig struct {
 	// Name is the desired cookie name.
@@ -21,15 +23,19 @@ type CookieConfig struct {
 	// Secure flag indicating to the browser that the cookie should only be
 	// transmitted over a TLS HTTPS connection. Recommended true in production.
 	Secure bool
+	// SameSite attribute modes indicates that a browser not send a cookie in
+	// cross-site requests.
+	SameSite http.SameSite
 }
 
 // DefaultCookieConfig configures short-lived temporary http.Cookie creation.
 var DefaultCookieConfig = CookieConfig{
 	Name:     "gologin-temporary-cookie",
 	Path:     "/",
-	MaxAge:   60, // 60 seconds
+	MaxAge:   600, // 10 min
 	HTTPOnly: true,
 	Secure:   true, // HTTPS only
+	SameSite: http.SameSiteLaxMode,
 }
 
 // DebugOnlyCookieConfig configures creation of short-lived temporary
@@ -38,7 +44,8 @@ var DefaultCookieConfig = CookieConfig{
 var DebugOnlyCookieConfig = CookieConfig{
 	Name:     "gologin-temporary-cookie",
 	Path:     "/",
-	MaxAge:   60, // 60 seconds
+	MaxAge:   600, // 10 min
 	HTTPOnly: true,
 	Secure:   false, // allows cookies to be send over HTTP
+	SameSite: http.SameSiteLaxMode,
 }

--- a/internal/cookie.go
+++ b/internal/cookie.go
@@ -21,6 +21,7 @@ func NewCookie(config gologin.CookieConfig, value string) *http.Cookie {
 		MaxAge:   config.MaxAge,
 		HttpOnly: config.HTTPOnly,
 		Secure:   config.Secure,
+		SameSite: config.SameSite,
 	}
 	// IE <9 does not understand MaxAge, set Expires if MaxAge is non-zero.
 	if expires, ok := expiresTime(config.MaxAge); ok {


### PR DESCRIPTION
* Add SameSite to the CookieConfig to allow configuring the SameSite attribute on the temporary state cookie used by OAuth2
* Set strict mode on the DefaultCookieConfig
* Set none mode on the DebugOnlyCookieConfig