### PR TITLE
Update examples to show sessions with typed values

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,10 +4,13 @@ Notable changes between releases.
 
 ## Latest
 
+## v2.4.0
+
 * Add `SameSite` field to the oauth2 state `CookieConfig` ([#112](https://github.com/dghubble/gologin/pull/112))
   * Set `SameSiteLaxMode` in `DefaultCookieConfig` and `DebugOnlyCookieConfig`
 * Raise the `MaxAge` in `DefaultCookieConfig` and `DebugOnlyCookieConfig`
   * Allow 10 min for users to complete the authorization flow
+* Update examples to show sessions with typed values ([#123](https://github.com/dghubble/gologin/pull/123))
 
 ## v2.3.1
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# gologin [![GoDoc](https://pkg.go.dev/badge/github.com/dghubble/gologin.svg)](https://pkg.go.dev/github.com/dghubble/gologin) [![Workflow](https://github.com/dghubble/gologin/actions/workflows/test.yaml/badge.svg)](https://github.com/dghubble/gologin/actions/workflows/test.yaml?query=branch%3Amain) [![Sponsors](https://img.shields.io/github/sponsors/dghubble?logo=github)](https://github.com/sponsors/dghubble) [![Mastodon](https://img.shields.io/badge/follow-news-6364ff?logo=mastodon)](https://fosstodon.org/@typhoon)
+# gologin
+[![GoDoc](https://pkg.go.dev/badge/github.com/dghubble/gologin.svg)](https://pkg.go.dev/github.com/dghubble/gologin)
+[![Workflow](https://github.com/dghubble/gologin/actions/workflows/test.yaml/badge.svg)](https://github.com/dghubble/gologin/actions/workflows/test.yaml?query=branch%3Amain)
+[![Sponsors](https://img.shields.io/github/sponsors/dghubble?logo=github)](https://github.com/sponsors/dghubble)
+[![Mastodon](https://img.shields.io/badge/follow-news-6364ff?logo=mastodon)](https://fosstodon.org/@dghubble)
 
 <img align="right" src="https://storage.googleapis.com/dghubble/gologin.png">
 
@@ -15,10 +19,6 @@ See [examples](examples) for tutorials with apps you can run from the command li
 * Obtain the user or access token from the `context`
 * Configurable OAuth 2 state parameter handling (CSRF protection)
 * Configurable OAuth 1 request secret handling
-
-## Install
-
-    go get github.com/dghubble/gologin
 
 ## Docs
 
@@ -39,6 +39,15 @@ Let's walk through Github and Twitter web login examples.
 Register the `LoginHandler` and `CallbackHandler` on your `http.ServeMux`.
 
 ```go
+import (
+    ...
+    "github.com/dghubble/gologin/v2"
+	"github.com/dghubble/gologin/v2/github"
+	"golang.org/x/oauth2"
+	githubOAuth2 "golang.org/x/oauth2/github"
+)
+...
+
 config := &oauth2.Config{
     ClientID:     "GithubClientID",
     ClientSecret: "GithubClientSecret",

--- a/examples/github/main.go
+++ b/examples/github/main.go
@@ -22,7 +22,7 @@ const (
 )
 
 // sessionStore encodes and decodes session data stored in signed cookies
-var sessionStore = sessions.NewCookieStore(sessions.DebugCookieConfig, []byte(sessionSecret), nil)
+var sessionStore = sessions.NewCookieStore[any](sessions.DebugCookieConfig, []byte(sessionSecret), nil)
 
 // Config configures the main ServeMux.
 type Config struct {

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/dghubble/gologin/v2 v2.3.1
 	github.com/dghubble/oauth1 v0.7.2
-	github.com/dghubble/sessions v0.3.0
+	github.com/dghubble/sessions v0.4.0
 	golang.org/x/oauth2 v0.4.0
 )
 

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -20,8 +20,8 @@ github.com/dghubble/gologin/v2 v2.3.1 h1:4E3JJ92UHQ5VSufbCmLwkbKhCd9Ffe/oIPnIrly
 github.com/dghubble/gologin/v2 v2.3.1/go.mod h1:CpUtWNSne5noIBfYWCyA0G/1aTdjV6+7hKZaNb6owaI=
 github.com/dghubble/oauth1 v0.7.2 h1:pwcinOZy8z6XkNxvPmUDY52M7RDPxt0Xw1zgZ6Cl5JA=
 github.com/dghubble/oauth1 v0.7.2/go.mod h1:9erQdIhqhOHG/7K9s/tgh9Ks/AfoyrO5mW/43Lu2+kE=
-github.com/dghubble/sessions v0.3.0 h1:kuPH18gk0e8FrD+98rIKAfL8cu5id5yRb5tof2wnkCM=
-github.com/dghubble/sessions v0.3.0/go.mod h1:MhijRC0x35DdMcBzVaPCvIvlSEiGg0a6L8Ra1VsHoFw=
+github.com/dghubble/sessions v0.4.0 h1:DcAlR3HGxoKdxXRhU0I3lHNhrJ3HnP6fmpZ5lCnTHkM=
+github.com/dghubble/sessions v0.4.0/go.mod h1:MhijRC0x35DdMcBzVaPCvIvlSEiGg0a6L8Ra1VsHoFw=
 github.com/dghubble/sling v1.4.1 h1:AxjTubpVyozMvbBCtXcsWEyGGgUZutC5YGrfxPNVOcQ=
 github.com/dghubble/sling v1.4.1/go.mod h1:QoMB1KL3GAo+7HsD8Itd6S+6tW91who8BGZzuLvpOyc=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/examples/google/main.go
+++ b/examples/google/main.go
@@ -22,7 +22,7 @@ const (
 )
 
 // sessionStore encodes and decodes session data stored in signed cookies
-var sessionStore = sessions.NewCookieStore(sessions.DebugCookieConfig, []byte(sessionSecret), nil)
+var sessionStore = sessions.NewCookieStore[string](sessions.DebugCookieConfig, []byte(sessionSecret), nil)
 
 // Config configures the main ServeMux.
 type Config struct {

--- a/examples/twitter/main.go
+++ b/examples/twitter/main.go
@@ -21,7 +21,7 @@ const (
 )
 
 // sessionStore encodes and decodes session data stored in signed cookies
-var sessionStore = sessions.NewCookieStore(sessions.DebugCookieConfig, []byte(sessionSecret), nil)
+var sessionStore = sessions.NewCookieStore[any](sessions.DebugCookieConfig, []byte(sessionSecret), nil)
 
 // Config configures the main ServeMux.
 type Config struct {


### PR DESCRIPTION
* Update github.com/dghubble/sessions to v0.4.0 in examples to show use of a session store with typed values