### PR TITLE
Testing: Remove testing for Go v1.18, add testing for Go v1.20

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.18', '1.19']
+        go: ['1.20', '1.19']
     steps:
       - name: setup
         uses: actions/setup-go@v3


### PR DESCRIPTION
Following the Go release cycle