### PR TITLE
Correct spelling for 'GitHub' word

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,11 +31,11 @@ Notable changes between releases.
 
 ## v2.1.0
 
-* Add `EnterpriseCallbackHandler` for Github Enterprise ([#33](https://github.com/dghubble/gologin/pull/33))
+* Add `EnterpriseCallbackHandler` for GitHub Enterprise ([#33](https://github.com/dghubble/gologin/pull/33))
 * Add email address to Facebook Users ([0acc88](https://github.com/dghubble/gologin/commit/0acc881e40b4926bbba0c02944ad5842700a0eab))
 * Update Facebook API version to v2.9 ([0acc88](https://github.com/dghubble/gologin/commit/0acc881e40b4926bbba0c02944ad5842700a0eab))
 * Fix facebook `CallbackHandler` to pass Facebook errors ([#31](https://github.com/dghubble/gologin/pull/31))
-* Fix Github Users.Get call to accomodate a `go-github` [change](https://github.com/google/go-github/pull/529) ([#18](https://github.com/dghubble/gologin/pull/18))
+* Fix GitHub Users.Get call to accomodate a `go-github` [change](https://github.com/google/go-github/pull/529) ([#18](https://github.com/dghubble/gologin/pull/18))
 * Remove deprecated `digits` subpackage ([#29](https://github.com/dghubble/gologin/pull/29))
 
 ## v2.0.0
@@ -63,12 +63,12 @@ Notable changes between releases.
 
 * Official release using the `ContextHandler`
 * Support for all OAuth1 and Oauth2 providers
-* Convenience handlers for Google, Github, Facebook, Bitbucket, Twitter, Digits, and Tumblr
+* Convenience handlers for Google, GitHub, Facebook, Bitbucket, Twitter, Digits, and Tumblr
 * Token login handlers for Twitter and Digits
 
 ## v0.1.0
 
 * Initial proof of concept
-* Web login handlers for Google, Github, Facebook, Bitbucket, Twitter, Digits, and Tumblr
+* Web login handlers for Google, GitHub, Facebook, Bitbucket, Twitter, Digits, and Tumblr
 * Token login handlers for Twitter and Digits
 * Support for OAuth1 and OAuth2

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <img align="right" src="https://storage.googleapis.com/dghubble/gologin.png">
 
-Package `gologin` provides chainable login `http.Handler`'s for [Google](http://godoc.org/github.com/dghubble/gologin/google), [Github](http://godoc.org/github.com/dghubble/gologin/github), [Twitter](http://godoc.org/github.com/dghubble/gologin/twitter), [Facebook](http://godoc.org/github.com/dghubble/gologin/facebook), [Bitbucket](http://godoc.org/github.com/dghubble/gologin/bitbucket), [Tumblr](http://godoc.org/github.com/dghubble/gologin/tumblr), or any [OAuth1](http://godoc.org/github.com/dghubble/gologin/oauth1) or [OAuth2](http://godoc.org/github.com/dghubble/gologin/oauth2) authentication providers.
+Package `gologin` provides chainable login `http.Handler`'s for [Google](http://godoc.org/github.com/dghubble/gologin/google), [GitHub](http://godoc.org/github.com/dghubble/gologin/github), [Twitter](http://godoc.org/github.com/dghubble/gologin/twitter), [Facebook](http://godoc.org/github.com/dghubble/gologin/facebook), [Bitbucket](http://godoc.org/github.com/dghubble/gologin/bitbucket), [Tumblr](http://godoc.org/github.com/dghubble/gologin/tumblr), or any [OAuth1](http://godoc.org/github.com/dghubble/gologin/oauth1) or [OAuth2](http://godoc.org/github.com/dghubble/gologin/oauth2) authentication providers.
 
 Choose a subpackage. Register the `LoginHandler` and `CallbackHandler` for web logins or the `TokenHandler` for (mobile) token logins. Get the authenticated user or access token from the request `context`.
 
@@ -30,11 +30,11 @@ Package `gologin` provides `http.Handler`'s which can be chained together to imp
 
 ## Usage
 
-Choose a subpackage such as `github` or `twitter`. `LoginHandler` and `Callback` `http.Handler`'s chain together lower level `oauth1` or `oauth2` handlers to authenticate users and fetch the Github or Twitter `User`, before calling your `success` `http.Handler`.
+Choose a subpackage such as `github` or `twitter`. `LoginHandler` and `Callback` `http.Handler`'s chain together lower level `oauth1` or `oauth2` handlers to authenticate users and fetch the GitHub or Twitter `User`, before calling your `success` `http.Handler`.
 
-Let's walk through Github and Twitter web login examples.
+Let's walk through GitHub and Twitter web login examples.
 
-### Github OAuth2
+### GitHub OAuth2
 
 Register the `LoginHandler` and `CallbackHandler` on your `http.ServeMux`.
 
@@ -64,11 +64,11 @@ The `StateHandler` checks for an OAuth2 state parameter cookie, generates a non-
 
 The `github` `LoginHandler` reads the state from the ctx and redirects to the AuthURL (at github.com) to prompt the user to grant access. Passing nil for the `failure` handler just means the `DefaultFailureHandler` should be used, which reports errors. ([info](#failure-handlers))
 
-The `github` `CallbackHandler` receives an auth code and state OAuth2 redirection, validates the state against the state in the ctx, and exchanges the auth code for an OAuth2 Token. The `github` CallbackHandler wraps the lower level `oauth2` `CallbackHandler` to further use the Token to obtain the Github `User` before calling through to the success or failure handlers.
+The `github` `CallbackHandler` receives an auth code and state OAuth2 redirection, validates the state against the state in the ctx, and exchanges the auth code for an OAuth2 Token. The `github` CallbackHandler wraps the lower level `oauth2` `CallbackHandler` to further use the Token to obtain the GitHub `User` before calling through to the success or failure handlers.
 
 <img src="https://storage.googleapis.com/dghubble/gologin-github.png">
 
-Next, write the success `http.Handler` to do something with the Token and Github User added to the `ctx`.
+Next, write the success `http.Handler` to do something with the Token and GitHub User added to the `ctx`.
 
 ```go
 func issueSession() http.Handler {
@@ -82,7 +82,7 @@ func issueSession() http.Handler {
 }
 ```
 
-See the [Github tutorial](examples/github) for a web app you can run from the command line.
+See the [GitHub tutorial](examples/github) for a web app you can run from the command line.
 
 ### Twitter OAuth1
 

--- a/examples/github/home.html
+++ b/examples/github/home.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Github Example</title>
+    <title>GitHub Example</title>
     <style>
       a.button {
         text-decoration: none;
@@ -12,6 +12,6 @@
   </head>
 
   <body>
-    <a href="/github/login" class="button">Login with Github</a>
+    <a href="/github/login" class="button">Login with GitHub</a>
   </body>
 </html>

--- a/examples/github/main.go
+++ b/examples/github/main.go
@@ -49,7 +49,7 @@ func New(config *Config) *http.ServeMux {
 	return mux
 }
 
-// issueSession issues a cookie session after successful Github login
+// issueSession issues a cookie session after successful GitHub login
 func issueSession() http.Handler {
 	fn := func(w http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
@@ -101,8 +101,8 @@ func main() {
 		GithubClientSecret: os.Getenv("GITHUB_CLIENT_SECRET"),
 	}
 	// allow consumer credential flags to override config fields
-	clientID := flag.String("client-id", "", "Github Client ID")
-	clientSecret := flag.String("client-secret", "", "Github Client Secret")
+	clientID := flag.String("client-id", "", "GitHub Client ID")
+	clientSecret := flag.String("client-secret", "", "GitHub Client Secret")
 	flag.Parse()
 	if *clientID != "" {
 		config.GithubClientID = *clientID
@@ -111,10 +111,10 @@ func main() {
 		config.GithubClientSecret = *clientSecret
 	}
 	if config.GithubClientID == "" {
-		log.Fatal("Missing Github Client ID")
+		log.Fatal("Missing GitHub Client ID")
 	}
 	if config.GithubClientSecret == "" {
-		log.Fatal("Missing Github Client Secret")
+		log.Fatal("Missing GitHub Client Secret")
 	}
 
 	log.Printf("Starting Server listening on %s\n", address)

--- a/github/context.go
+++ b/github/context.go
@@ -14,16 +14,16 @@ const (
 	userKey key = iota
 )
 
-// WithUser returns a copy of ctx that stores the Github User.
+// WithUser returns a copy of ctx that stores the GitHub User.
 func WithUser(ctx context.Context, user *github.User) context.Context {
 	return context.WithValue(ctx, userKey, user)
 }
 
-// UserFromContext returns the Github User from the ctx.
+// UserFromContext returns the GitHub User from the ctx.
 func UserFromContext(ctx context.Context) (*github.User, error) {
 	user, ok := ctx.Value(userKey).(*github.User)
 	if !ok {
-		return nil, fmt.Errorf("github: Context missing Github User")
+		return nil, fmt.Errorf("github: Context missing GitHub User")
 	}
 	return user, nil
 }

--- a/github/context_test.go
+++ b/github/context_test.go
@@ -11,7 +11,7 @@ import (
 func TestContextUser(t *testing.T) {
 	expectedUser := &github.User{
 		ID:   github.Int64(917408),
-		Name: github.String("Github User"),
+		Name: github.String("GitHub User"),
 	}
 	ctx := WithUser(context.Background(), expectedUser)
 	user, err := UserFromContext(ctx)
@@ -23,6 +23,6 @@ func TestContextUser_Error(t *testing.T) {
 	user, err := UserFromContext(context.Background())
 	assert.Nil(t, user)
 	if assert.NotNil(t, err) {
-		assert.Equal(t, "github: Context missing Github User", err.Error())
+		assert.Equal(t, "github: Context missing GitHub User", err.Error())
 	}
 }

--- a/github/doc.go
+++ b/github/doc.go
@@ -1,2 +1,2 @@
-// Package github provides Github OAuth2 login and callback handlers.
+// Package github provides GitHub OAuth2 login and callback handlers.
 package github

--- a/github/login.go
+++ b/github/login.go
@@ -12,9 +12,9 @@ import (
 	"golang.org/x/oauth2"
 )
 
-// Github login errors
+// GitHub login errors
 var (
-	ErrUnableToGetGithubUser = errors.New("github: unable to get Github User")
+	ErrUnableToGetGithubUser = errors.New("github: unable to get GitHub User")
 )
 
 // StateHandler checks for a state cookie. If found, the state value is read
@@ -29,13 +29,13 @@ func StateHandler(config gologin.CookieConfig, success http.Handler) http.Handle
 	return oauth2Login.StateHandler(config, success)
 }
 
-// LoginHandler handles Github login requests by reading the state value from
+// LoginHandler handles GitHub login requests by reading the state value from
 // the ctx and redirecting requests to the AuthURL with that state value.
 func LoginHandler(config *oauth2.Config, failure http.Handler) http.Handler {
 	return oauth2Login.LoginHandler(config, failure)
 }
 
-// CallbackHandler handles Github redirection URI requests and adds the Github
+// CallbackHandler handles GitHub redirection URI requests and adds the GitHub
 // access token and User to the ctx. If authentication succeeds, handling
 // delegates to the success handler, otherwise to the failure handler.
 func CallbackHandler(config *oauth2.Config, success, failure http.Handler) http.Handler {
@@ -43,10 +43,10 @@ func CallbackHandler(config *oauth2.Config, success, failure http.Handler) http.
 	return oauth2Login.CallbackHandler(config, success, failure)
 }
 
-// EnterpriseCallbackHandler handles Github Enterprise redirection URI requests
-// and adds the Github access token and User to the ctx. If authentication
+// EnterpriseCallbackHandler handles GitHub Enterprise redirection URI requests
+// and adds the GitHub access token and User to the ctx. If authentication
 // succeeds,handling delegates to the success handler, otherwise to the failure
-// handler. The Github Enterprise API URL is inferred from the OAuth2 config's
+// handler. The GitHub Enterprise API URL is inferred from the OAuth2 config's
 // AuthURL endpoint.
 func EnterpriseCallbackHandler(config *oauth2.Config, success, failure http.Handler) http.Handler {
 	success = githubHandler(config, true, success, failure)
@@ -54,7 +54,7 @@ func EnterpriseCallbackHandler(config *oauth2.Config, success, failure http.Hand
 }
 
 // githubHandler is a http.Handler that gets the OAuth2 Token from the ctx to
-// get the corresponding Github User. If successful, the User is added to the
+// get the corresponding GitHub User. If successful, the User is added to the
 // ctx and the success handler is called. Otherwise, the failure handler is
 // called.
 func githubHandler(config *oauth2.Config, isEnterprise bool, success, failure http.Handler) http.Handler {
@@ -95,7 +95,7 @@ func githubHandler(config *oauth2.Config, isEnterprise bool, success, failure ht
 	return http.HandlerFunc(fn)
 }
 
-// validateResponse returns an error if the given Github user, raw
+// validateResponse returns an error if the given GitHub user, raw
 // http.Response, or error are unexpected. Returns nil if they are valid.
 func validateResponse(user *github.User, resp *github.Response, err error) error {
 	if err != nil || resp.StatusCode != http.StatusOK {
@@ -107,7 +107,7 @@ func validateResponse(user *github.User, resp *github.Response, err error) error
 	return nil
 }
 
-// enterpriseGithubClientFromAuthURL returns a Github client that targets a GHE instance.
+// enterpriseGithubClientFromAuthURL returns a GitHub client that targets a GHE instance.
 func enterpriseGithubClientFromAuthURL(authURL string, httpClient *http.Client) (*github.Client, error) {
 	client := github.NewClient(httpClient)
 

--- a/github/login_test.go
+++ b/github/login_test.go
@@ -37,8 +37,8 @@ func TestGithubHandler(t *testing.T) {
 	failure := testutils.AssertFailureNotCalled(t)
 
 	// GithubHandler assert that:
-	// - Token is read from the ctx and passed to the Github API
-	// - github User is obtained from the Github API
+	// - Token is read from the ctx and passed to the GitHub API
+	// - github User is obtained from the GitHub API
 	// - success handler is called
 	// - github User is added to the ctx of the success handler
 	githubHandler := githubHandler(config, false, http.HandlerFunc(success), failure)
@@ -71,7 +71,7 @@ func TestGithubHandler_MissingCtxToken(t *testing.T) {
 }
 
 func TestGithubHandler_ErrorGettingUser(t *testing.T) {
-	proxyClient, server := testutils.NewErrorServer("Github Service Down", http.StatusInternalServerError)
+	proxyClient, server := testutils.NewErrorServer("GitHub Service Down", http.StatusInternalServerError)
 	defer server.Close()
 	// oauth2 Client will use the proxy client's base Transport
 	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, proxyClient)
@@ -89,9 +89,9 @@ func TestGithubHandler_ErrorGettingUser(t *testing.T) {
 		fmt.Fprintf(w, "failure handler called")
 	}
 
-	// GithubHandler cannot get Github User, assert that:
+	// GithubHandler cannot get GitHub User, assert that:
 	// - failure handler is called
-	// - error cannot get Github User added to the failure handler ctx
+	// - error cannot get GitHub User added to the failure handler ctx
 	githubHandler := githubHandler(config, false, success, http.HandlerFunc(failure))
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/", nil)
@@ -122,8 +122,8 @@ func TestGithubHandler_Enterprise(t *testing.T) {
 	failure := testutils.AssertFailureNotCalled(t)
 
 	// GithubHandler assert that:
-	// - Token is read from the ctx and passed to the Github API
-	// - github User is obtained from the Github API
+	// - Token is read from the ctx and passed to the GitHub API
+	// - github User is obtained from the GitHub API
 	// - success handler is called
 	// - github User is added to the ctx of the success handler
 	githubHandler := githubHandler(config, true, http.HandlerFunc(success), failure)

--- a/github/server_test.go
+++ b/github/server_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/dghubble/gologin/v2/testutils"
 )
 
-// newGithubTestServer returns a new httptest.Server which mocks the Github user
+// newGithubTestServer returns a new httptest.Server which mocks the GitHub user
 // endpoint and a client which proxies requests to the server. The server
 // responds with the given json data. The caller must close the server. The
 // routePrefix parameter specifies an optional route prefix that should be set


### PR DESCRIPTION
This PR replaces `Github` with `GitHub`. See https://github.com/logos