### PR TITLE
Get rid of deprecated functions and packages

### DIFF
--- a/google/login.go
+++ b/google/login.go
@@ -8,6 +8,7 @@ import (
 	oauth2Login "github.com/dghubble/gologin/v2/oauth2"
 	"golang.org/x/oauth2"
 	google "google.golang.org/api/oauth2/v2"
+	"google.golang.org/api/option"
 )
 
 // Google login errors
@@ -59,7 +60,7 @@ func googleHandler(config *oauth2.Config, success, failure http.Handler) http.Ha
 			return
 		}
 		httpClient := config.Client(ctx, token)
-		googleService, err := google.New(httpClient)
+		googleService, err := google.NewService(ctx, option.WithHTTPClient(httpClient))
 		if err != nil {
 			ctx = gologin.WithError(ctx, err)
 			failure.ServeHTTP(w, req.WithContext(ctx))

--- a/oauth1/login_test.go
+++ b/oauth1/login_test.go
@@ -108,7 +108,7 @@ func TestAuthRedirectHandler(t *testing.T) {
 	ctx := WithRequestToken(context.Background(), requestToken, "")
 	authRedirectHandler.ServeHTTP(w, req.WithContext(ctx))
 	assert.Equal(t, http.StatusFound, w.Code)
-	assert.Equal(t, expectedRedirect, w.HeaderMap.Get("Location"))
+	assert.Equal(t, expectedRedirect, w.Result().Header.Get("Location"))
 }
 
 func TestAuthRedirectHandler_MissingCtxRequestToken(t *testing.T) {

--- a/oauth2/login_test.go
+++ b/oauth2/login_test.go
@@ -39,7 +39,7 @@ func TestLoginHandler(t *testing.T) {
 	ctx := WithState(context.Background(), expectedState)
 	loginHandler.ServeHTTP(w, req.WithContext(ctx))
 	assert.Equal(t, http.StatusFound, w.Code)
-	assert.Equal(t, expectedRedirect, w.HeaderMap.Get("Location"))
+	assert.Equal(t, expectedRedirect, w.Result().Header.Get("Location"))
 }
 
 func TestLoginHandler_MissingCtxState(t *testing.T) {

--- a/testutils/asserts.go
+++ b/testutils/asserts.go
@@ -3,7 +3,6 @@ package testutils
 
 import (
 	"io"
-	"io/ioutil"
 	"net/http"
 	"testing"
 
@@ -29,7 +28,7 @@ func AssertFailureNotCalled(t *testing.T) http.Handler {
 // AssertBodyString asserts that a Request Body matches the expected string.
 func AssertBodyString(t *testing.T, rc io.ReadCloser, expected string) {
 	defer rc.Close()
-	if b, err := ioutil.ReadAll(rc); err == nil {
+	if b, err := io.ReadAll(rc); err == nil {
 		if string(b) != expected {
 			t.Errorf("expected %q, got %q", expected, string(b))
 		}


### PR DESCRIPTION
This PR fixes the following [`staticcheck`](https://honnef.co/go/tools/cmd/staticcheck) lint issues:
```
testutils/asserts.go:6:2: SA1019: "io/ioutil" has been deprecated since Go 1.19: As of Go 1.16, the same functionality is now provided by package [io] or package [os], and those implementations should be preferred in new code. See the specific function documentation for details. (staticcheck)
oauth2/login_test.go:42:36: SA1019: w.HeaderMap has been deprecated since Go 1.11 and an alternative has been available since Go 1.7: HeaderMap exists for historical compatibility and should not be used. To access the headers returned by a handler, use the Response.Header map as returned by the Result method. (staticcheck)
google/login.go:62:25: SA1019: google.New is deprecated: please use NewService instead. To provide a custom HTTP client, use option.WithHTTPClient. If you are using google.golang.org/api/googleapis/transport.APIKey, use option.WithAPIKey with NewService instead. (staticcheck)
oauth1/login_test.go:111:36: SA1019: w.HeaderMap has been deprecated since Go 1.11 and an alternative has been available since Go 1.7: HeaderMap exists for historical compatibility and should not be used. To access the headers returned by a handler, use the Response.Header map as returned by the Result method. (staticcheck)
```