### PR TITLE
Add GitHub Workflow to enable auto-merge on dependabot PRs

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -1,0 +1,16 @@
+name: dependabot
+on:
+  pull_request:
+jobs:
+  enable-auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Enable auto-merge for Dependabot PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --auto --rebase "$PR_URL"


### PR DESCRIPTION
* Set dependabot PRs to auto-merge to use the GitHub native auto-merge feature which waits for required checks to pass and then merges without human involvement